### PR TITLE
breaking(hooks): rename 'field'/'inputField' hooks into parent namespace

### DIFF
--- a/packages/graphql-build-pg/src/plugins/PgConnectionArgCondition.js
+++ b/packages/graphql-build-pg/src/plugins/PgConnectionArgCondition.js
@@ -63,7 +63,7 @@ export default (function PgConnectionArgCondition(
     }
   );
   builder.hook(
-    "field:args",
+    "GraphQLObjectType:fields:field:args",
     (
       args,
       {

--- a/packages/graphql-build-pg/src/plugins/PgConnectionArgFirstLastBeforeAfter.js
+++ b/packages/graphql-build-pg/src/plugins/PgConnectionArgFirstLastBeforeAfter.js
@@ -5,7 +5,7 @@ const base64Decode = str => new Buffer(String(str), "base64").toString("utf8");
 
 export default (function PgConnectionArgs(builder) {
   builder.hook(
-    "field:args",
+    "GraphQLObjectType:fields:field:args",
     (
       args,
       { extend, getTypeByName, graphql: { GraphQLInt } },

--- a/packages/graphql-build-pg/src/plugins/PgConnectionArgOrderBy.js
+++ b/packages/graphql-build-pg/src/plugins/PgConnectionArgOrderBy.js
@@ -46,7 +46,7 @@ export default (function PgConnectionArgOrderBy(
     }
   );
   builder.hook(
-    "field:args",
+    "GraphQLObjectType:fields:field:args",
     (
       args,
       { extend, getTypeByName, pgSql: sql },

--- a/packages/graphql-build/README.md
+++ b/packages/graphql-build/README.md
@@ -123,6 +123,9 @@ Hooks
   - `GraphQLObjectType:fields` to add additional fields to this object type (is
     ran asynchronously and gets a reference to the final GraphQL Object as
     `Self` in the context)
+  - `GraphQLObjectType:fields:field`: to add any root-level attributes to an
+    individual field, e.g. add a description
+  - `GraphQLObjectType:fields:field:args` to add arguments to an individual field
 
 - `GraphQLInputObjectType*`: When creating a GraphQLInputObjectType via
   `newWithHooks`, we'll execute, the following hooks:
@@ -131,21 +134,13 @@ Hooks
   - `GraphQLInputObjectType:fields` to add additional fields to this object type (is
     ran asynchronously and gets a reference to the final GraphQL Object as
     `Self` in the context)
+  - `GraphQLInputObjectType:fields:field`: to customize an individual field from above
 
 - `GraphQLEnumType*`: When creating a GraphQLEnumType via `newWithHooks`,
   we'll execute, the following hooks:
 
   - `GraphQLEnumType` to add any root-level attributes, e.g. add a description
   - `GraphQLEnumType:values` to add additional values
-
-- `field*`: When you add a field to a GraphQLObjectType, wrap the call with
-  `fieldWithHooks` in order to fire these hooks:
-
-  - `field`: to add any root-level attributes, e.g. add a description
-  - `field:args` to add arguments
-
-- `inputField`: When you add a field to a GraphQLInputObjectType, wrap the call
-  with `fieldWithHooks` in order to fire this hook
 
 
 Conventions

--- a/packages/graphql-build/src/SchemaBuilder.js
+++ b/packages/graphql-build/src/SchemaBuilder.js
@@ -186,9 +186,13 @@ class SchemaBuilder extends EventEmitter {
       // - 'GraphQLObjectType:fields' to add additional fields to this object type (is
       //   ran asynchronously and gets a reference to the final GraphQL Object as
       //   `Self` in the context)
+      // - 'GraphQLObjectType:fields:field' to customise an individual field from above
+      // - 'GraphQLObjectType:fields:field:args' to customize the arguments to a field
       GraphQLObjectType: [],
       "GraphQLObjectType:interfaces": [],
       "GraphQLObjectType:fields": [],
+      "GraphQLObjectType:fields:field": [],
+      "GraphQLObjectType:fields:field:args": [],
 
       // When creating a GraphQLInputObjectType via `newWithHooks`, we'll
       // execute, the following hooks:
@@ -196,8 +200,10 @@ class SchemaBuilder extends EventEmitter {
       // - 'GraphQLInputObjectType:fields' to add additional fields to this object type (is
       //   ran asynchronously and gets a reference to the final GraphQL Object as
       //   `Self` in the context)
+      // - 'GraphQLInputObjectType:fields:field' to customise an individual field from above
       GraphQLInputObjectType: [],
       "GraphQLInputObjectType:fields": [],
+      "GraphQLInputObjectType:fields:field": [],
 
       // When creating a GraphQLEnumType via `newWithHooks`, we'll
       // execute, the following hooks:
@@ -205,15 +211,6 @@ class SchemaBuilder extends EventEmitter {
       // - 'GraphQLEnumType:values' to add additional values
       GraphQLEnumType: [],
       "GraphQLEnumType:values": [],
-
-      // When you add a field to a GraphQLObjectType, wrap the call with
-      // `fieldWithHooks` in order to fire these hooks:
-      field: [],
-      "field:args": [],
-
-      // When you add a field to a GraphQLInputObjectType, wrap the call with
-      // `fieldWithHooks` in order to fire this hook:
-      inputField: [],
     };
   }
 

--- a/packages/graphql-build/src/makeNewBuild.js
+++ b/packages/graphql-build/src/makeNewBuild.js
@@ -368,7 +368,7 @@ export default function makeNewBuild(builder: SchemaBuilder): Build {
                 }
                 newSpec = builder.applyHooks(
                   this,
-                  "field",
+                  "GraphQLObjectType:fields:field",
                   newSpec,
                   context,
                   `|${getNameFromType(Self)}.fields.${fieldName}`
@@ -377,7 +377,7 @@ export default function makeNewBuild(builder: SchemaBuilder): Build {
                 newSpec = Object.assign({}, newSpec, {
                   args: builder.applyHooks(
                     this,
-                    "field:args",
+                    "GraphQLObjectType:fields:field:args",
                     newSpec.args,
                     Object.assign({}, context, {
                       field: newSpec,
@@ -458,7 +458,7 @@ export default function makeNewBuild(builder: SchemaBuilder): Build {
                 }
                 newSpec = builder.applyHooks(
                   this,
-                  "inputField",
+                  "GraphQLInputObjectType:fields:field",
                   newSpec,
                   context,
                   `|${getNameFromType(Self)}.fields.${fieldName}`

--- a/packages/graphql-build/src/plugins/ClientMutationIdDescriptionPlugin.js
+++ b/packages/graphql-build/src/plugins/ClientMutationIdDescriptionPlugin.js
@@ -5,7 +5,7 @@ export default (function ClientMutationIdDescriptionPlugin(
   builder: SchemaBuilder
 ) {
   builder.hook(
-    "inputField",
+    "GraphQLInputObjectType:fields:field",
     (field: {}, { extend }, { scope: { isMutationInput, fieldName } }) => {
       if (
         !isMutationInput ||
@@ -22,7 +22,7 @@ export default (function ClientMutationIdDescriptionPlugin(
   );
 
   builder.hook(
-    "field",
+    "GraphQLObjectType:fields:field",
     (field: {}, { extend }, { scope: { isMutationPayload, fieldName } }) => {
       if (
         !isMutationPayload ||
@@ -39,7 +39,7 @@ export default (function ClientMutationIdDescriptionPlugin(
   );
 
   builder.hook(
-    "field:args",
+    "GraphQLObjectType:fields:field:args",
     (args: {}, { extend }, { scope: { isRootMutation } }) => {
       if (!isRootMutation || !args.input || args.input.description) {
         return args;


### PR DESCRIPTION
This moves `field` to `GraphQLObjectType:fields:field` (and `inputField` `GraphQLInputObjectType:fields:field`).

I decided not to call it `GraphQLObjectType:field` because it's too visually similar to `GraphQLObjectType:fields`; it's also more accurate from a hierarchy point of view.

This is a breaking change.