### PR TITLE
test(schema): add snapshots for generated schema

### DIFF
--- a/packages/postgraphql-build/__tests__/integration/__snapshots__/schema.test.js.snap
+++ b/packages/postgraphql-build/__tests__/integration/__snapshots__/schema.test.js.snap
@@ -1,0 +1,5973 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`prints a schema with Relay 1 style ids 1`] = `
+"# A signed eight-byte integer. The upper big integer values are greater then the
+# max value for a JavaScript number. Therefore all big integers will be output as
+# strings and not numbers.
+scalar BigInt
+
+type CompoundKey implements Node {
+  extra: Boolean
+
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  id: ID!
+
+  # Reads a single \`Person\` that is related to this \`CompoundKey\`.
+  personByPersonId1: Person!
+
+  # Reads a single \`Person\` that is related to this \`CompoundKey\`.
+  personByPersonId2: Person!
+  personId1: Int!
+  personId2: Int!
+}
+
+# A condition to be used against \`CompoundKey\` object types. All fields are tested
+# for equality and combined with a logical ‘and.’
+input CompoundKeyCondition {
+  # Checks for equality with the object’s \`extra\` field.
+  extra: Boolean
+
+  # Checks for equality with the object’s \`personId1\` field.
+  personId1: Int
+
+  # Checks for equality with the object’s \`personId2\` field.
+  personId2: Int
+}
+
+# An input for mutations affecting \`CompoundKey\`
+input CompoundKeyInput {
+  extra: Boolean
+  personId1: Int!
+  personId2: Int!
+}
+
+# Represents an update to a \`CompoundKey\`. Fields that are set will be updated.
+input CompoundKeyPatch {
+  extra: Boolean
+  personId1: Int
+  personId2: Int
+}
+
+# A connection to a list of \`CompoundKey\` values.
+type CompoundKeysConnection {
+  # A list of edges which contains the \`CompoundKey\` and cursor to aid in pagination.
+  edges: [CompoundKeysEdge!]!
+
+  # A list of \`CompoundKey\` objects.
+  nodes: [CompoundKey]!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`CompoundKey\` you could get from the connection.
+  totalCount: Int
+}
+
+# A \`CompoundKey\` edge in the connection.
+type CompoundKeysEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`CompoundKey\` at the end of the edge.
+  node: CompoundKey!
+}
+
+# Methods to use when ordering \`CompoundKey\`.
+enum CompoundKeysOrderBy {
+  EXTRA_ASC
+  EXTRA_DESC
+  NATURAL
+  PERSON_ID_1_ASC
+  PERSON_ID_1_DESC
+  PERSON_ID_2_ASC
+  PERSON_ID_2_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+# All input for the create \`CompoundKey\` mutation.
+input CreateCompoundKeyInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The \`CompoundKey\` to be created by this mutation.
+  compoundKey: CompoundKeyInput!
+}
+
+# The output of our create \`CompoundKey\` mutation.
+type CreateCompoundKeyPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # The \`CompoundKey\` that was created by this mutation.
+  compoundKey: CompoundKey
+
+  # An edge for the type. May be used by Relay 1.
+  compoundKeyEdge(
+    # The method to use when ordering \`CompoundKey\`.
+    orderBy: CompoundKeysOrderBy = PRIMARY_KEY_ASC
+  ): CompoundKeysEdge
+
+  # Reads a single \`Person\` that is related to this \`CompoundKey\`.
+  personByPersonId1: Person
+
+  # Reads a single \`Person\` that is related to this \`CompoundKey\`.
+  personByPersonId2: Person
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the create \`EdgeCase\` mutation.
+input CreateEdgeCaseInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The \`EdgeCase\` to be created by this mutation.
+  edgeCase: EdgeCaseInput!
+}
+
+# The output of our create \`EdgeCase\` mutation.
+type CreateEdgeCasePayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # The \`EdgeCase\` that was created by this mutation.
+  edgeCase: EdgeCase
+
+  # An edge for the type. May be used by Relay 1.
+  edgeCaseEdge(
+    # The method to use when ordering \`EdgeCase\`.
+    orderBy: EdgeCasesOrderBy = NATURAL
+  ): EdgeCasesEdge
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the create \`Person\` mutation.
+input CreatePersonInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The \`Person\` to be created by this mutation.
+  person: PersonInput!
+}
+
+# The output of our create \`Person\` mutation.
+type CreatePersonPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # The \`Person\` that was created by this mutation.
+  person: Person
+
+  # An edge for the type. May be used by Relay 1.
+  personEdge(
+    # The method to use when ordering \`Person\`.
+    orderBy: PeopleOrderBy = PRIMARY_KEY_ASC
+  ): PeopleEdge
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# A location in a connection that can be used for resuming pagination.
+scalar Cursor
+
+# A point in time as described by the [ISO
+# 8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
+scalar Datetime
+
+# All input for the \`deleteCompoundKeyByPersonId1AndPersonId2\` mutation.
+input DeleteCompoundKeyByPersonId1AndPersonId2Input {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  personId1: Int!
+  personId2: Int!
+}
+
+# All input for the \`deleteCompoundKey\` mutation.
+input DeleteCompoundKeyInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`CompoundKey\` to be deleted.
+  id: ID!
+}
+
+# The output of our delete \`CompoundKey\` mutation.
+type DeleteCompoundKeyPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # The \`CompoundKey\` that was deleted by this mutation.
+  compoundKey: CompoundKey
+
+  # An edge for the type. May be used by Relay 1.
+  compoundKeyEdge(
+    # The method to use when ordering \`CompoundKey\`.
+    orderBy: CompoundKeysOrderBy = PRIMARY_KEY_ASC
+  ): CompoundKeysEdge
+  deletedCompoundKeyId: ID
+
+  # Reads a single \`Person\` that is related to this \`CompoundKey\`.
+  personByPersonId1: Person
+
+  # Reads a single \`Person\` that is related to this \`CompoundKey\`.
+  personByPersonId2: Person
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`deletePersonByEmail\` mutation.
+input DeletePersonByEmailInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  email: Email!
+}
+
+# All input for the \`deletePersonByRowId\` mutation.
+input DeletePersonByRowIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  rowId: Int!
+}
+
+# All input for the \`deletePerson\` mutation.
+input DeletePersonInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`Person\` to be deleted.
+  id: ID!
+}
+
+# The output of our delete \`Person\` mutation.
+type DeletePersonPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  deletedPersonId: ID
+
+  # The \`Person\` that was deleted by this mutation.
+  person: Person
+
+  # An edge for the type. May be used by Relay 1.
+  personEdge(
+    # The method to use when ordering \`Person\`.
+    orderBy: PeopleOrderBy = PRIMARY_KEY_ASC
+  ): PeopleEdge
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+type EdgeCase implements Node {
+  computed: String
+
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  id: ID!
+  notNullHasDefault: Boolean!
+  rowId: Int
+  wontCastEasy: Int
+}
+
+# A condition to be used against \`EdgeCase\` object types. All fields are tested
+# for equality and combined with a logical ‘and.’
+input EdgeCaseCondition {
+  # Checks for equality with the object’s \`notNullHasDefault\` field.
+  notNullHasDefault: Boolean
+
+  # Checks for equality with the object’s \`rowId\` field.
+  rowId: Int
+
+  # Checks for equality with the object’s \`wontCastEasy\` field.
+  wontCastEasy: Int
+}
+
+# An input for mutations affecting \`EdgeCase\`
+input EdgeCaseInput {
+  notNullHasDefault: Boolean
+  rowId: Int
+  wontCastEasy: Int
+}
+
+# A connection to a list of \`EdgeCase\` values.
+type EdgeCasesConnection {
+  # A list of edges which contains the \`EdgeCase\` and cursor to aid in pagination.
+  edges: [EdgeCasesEdge!]!
+
+  # A list of \`EdgeCase\` objects.
+  nodes: [EdgeCase]!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`EdgeCase\` you could get from the connection.
+  totalCount: Int
+}
+
+# A \`EdgeCase\` edge in the connection.
+type EdgeCasesEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`EdgeCase\` at the end of the edge.
+  node: EdgeCase!
+}
+
+# Methods to use when ordering \`EdgeCase\`.
+enum EdgeCasesOrderBy {
+  NATURAL
+  NOT_NULL_HAS_DEFAULT_ASC
+  NOT_NULL_HAS_DEFAULT_DESC
+  ROW_ID_ASC
+  ROW_ID_DESC
+  WONT_CAST_EASY_ASC
+  WONT_CAST_EASY_DESC
+}
+
+scalar Email
+
+# The value at one end of a range. A range can either include this value, or not.
+input FloatRangeBoundInput {
+  # Whether or not the value of this bound is included in the range.
+  inclusive: Boolean!
+
+  # The value at one end of our range.
+  value: Float!
+}
+
+# A range of \`Float\`.
+input FloatRangeInput {
+  # The ending bound of our range.
+  end: FloatRangeBoundInput
+
+  # The starting bound of our range.
+  start: FloatRangeBoundInput
+}
+
+# All input for the \`intSetMutation\` mutation.
+input IntSetMutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  x: Int
+  y: Int
+  z: Int
+}
+
+# The output of our \`intSetMutation\` mutation.
+type IntSetMutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  integers: [Int]
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# A connection to a list of \`Int\` values.
+type IntSetQueryConnection {
+  # A list of edges which contains the \`Int\` and cursor to aid in pagination.
+  edges: [IntSetQueryEdge!]!
+
+  # A list of \`Int\` objects.
+  nodes: [Int]!
+}
+
+# A \`Int\` edge in the connection.
+type IntSetQueryEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`Int\` at the end of the edge.
+  node: Int
+}
+
+# A JavaScript object encoded in the JSON format as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+scalar JSON
+
+# All input for the \`jsonIdentityMutation\` mutation.
+input JsonIdentityMutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  json: JSON
+}
+
+# The output of our \`jsonIdentityMutation\` mutation.
+type JsonIdentityMutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  json: JSON
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# The root mutation type which contains root level fields which mutate data.
+type Mutation {
+  # Creates a single \`CompoundKey\`.
+  createCompoundKey(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CreateCompoundKeyInput!
+  ): CreateCompoundKeyPayload
+
+  # Creates a single \`EdgeCase\`.
+  createEdgeCase(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CreateEdgeCaseInput!
+  ): CreateEdgeCasePayload
+
+  # Creates a single \`Person\`.
+  createPerson(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CreatePersonInput!
+  ): CreatePersonPayload
+
+  # Deletes a single \`CompoundKey\` using its globally unique id.
+  deleteCompoundKey(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeleteCompoundKeyInput!
+  ): DeleteCompoundKeyPayload
+
+  # Deletes a single \`CompoundKey\` using a unique key.
+  deleteCompoundKeyByPersonId1AndPersonId2(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeleteCompoundKeyByPersonId1AndPersonId2Input!
+  ): DeleteCompoundKeyPayload
+
+  # Deletes a single \`Person\` using its globally unique id.
+  deletePerson(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeletePersonInput!
+  ): DeletePersonPayload
+
+  # Deletes a single \`Person\` using a unique key.
+  deletePersonByEmail(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeletePersonByEmailInput!
+  ): DeletePersonPayload
+
+  # Deletes a single \`Person\` using a unique key.
+  deletePersonByRowId(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeletePersonByRowIdInput!
+  ): DeletePersonPayload
+  intSetMutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: IntSetMutationInput!
+  ): IntSetMutationPayload!
+  jsonIdentityMutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: JsonIdentityMutationInput!
+  ): JsonIdentityMutationPayload!
+  noArgsMutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: NoArgsMutationInput!
+  ): NoArgsMutationPayload!
+
+  # Reads and enables pagination through a set of \`Post\`.
+  tableMutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: TableMutationInput!
+  ): TableMutationPayload!
+
+  # Reads and enables pagination through a set of \`Person\`.
+  tableSetMutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: TableSetMutationInput!
+  ): TableSetMutationPayload!
+  typesMutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: TypesMutationInput!
+  ): TypesMutationPayload!
+
+  # Updates a single \`CompoundKey\` using its globally unique id and a patch.
+  updateCompoundKey(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdateCompoundKeyInput!
+  ): UpdateCompoundKeyPayload
+
+  # Updates a single \`CompoundKey\` using a unique key and a patch.
+  updateCompoundKeyByPersonId1AndPersonId2(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdateCompoundKeyByPersonId1AndPersonId2Input!
+  ): UpdateCompoundKeyPayload
+
+  # Updates a single \`Person\` using its globally unique id and a patch.
+  updatePerson(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdatePersonInput!
+  ): UpdatePersonPayload
+
+  # Updates a single \`Person\` using a unique key and a patch.
+  updatePersonByEmail(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdatePersonByEmailInput!
+  ): UpdatePersonPayload
+
+  # Updates a single \`Person\` using a unique key and a patch.
+  updatePersonByRowId(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdatePersonByRowIdInput!
+  ): UpdatePersonPayload
+}
+
+# All input for the \`noArgsMutation\` mutation.
+input NoArgsMutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+}
+
+# The output of our \`noArgsMutation\` mutation.
+type NoArgsMutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  integer: Int
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# An object with a globally unique \`ID\`.
+interface Node {
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  id: ID!
+}
+
+# Information about pagination in a connection.
+type PageInfo {
+  # When paginating forwards, the cursor to continue.
+  endCursor: Cursor
+
+  # When paginating forwards, are there more items?
+  hasNextPage: Boolean!
+
+  # When paginating backwards, are there more items?
+  hasPreviousPage: Boolean!
+
+  # When paginating backwards, the cursor to continue.
+  startCursor: Cursor
+}
+
+# A connection to a list of \`Person\` values.
+type PeopleConnection {
+  # A list of edges which contains the \`Person\` and cursor to aid in pagination.
+  edges: [PeopleEdge!]!
+
+  # A list of \`Person\` objects.
+  nodes: [Person]!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`Person\` you could get from the connection.
+  totalCount: Int
+}
+
+# A \`Person\` edge in the connection.
+type PeopleEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`Person\` at the end of the edge.
+  node: Person!
+}
+
+# Methods to use when ordering \`Person\`.
+enum PeopleOrderBy {
+  ABOUT_ASC
+  ABOUT_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  EMAIL_ASC
+  EMAIL_DESC
+  ID_ASC
+  ID_DESC
+  NAME_ASC
+  NAME_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+# Person test comment
+type Person implements Node {
+  about: String
+
+  # Reads and enables pagination through a set of \`CompoundKey\`.
+  compoundKeysByPersonId1(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: CompoundKeyCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`CompoundKey\`.
+    orderBy: CompoundKeysOrderBy = PRIMARY_KEY_ASC
+  ): CompoundKeysConnection!
+
+  # Reads and enables pagination through a set of \`CompoundKey\`.
+  compoundKeysByPersonId2(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: CompoundKeyCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`CompoundKey\`.
+    orderBy: CompoundKeysOrderBy = PRIMARY_KEY_ASC
+  ): CompoundKeysConnection!
+  createdAt: Datetime
+  email: Email!
+  firstName: String
+
+  # Reads and enables pagination through a set of \`Post\`.
+  firstPost: Post
+
+  # Reads and enables pagination through a set of \`Person\`.
+  friends(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+  ): PeopleConnection!
+
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  id: ID!
+
+  # The person’s name
+  name: String!
+  rowId: Int!
+}
+
+# A condition to be used against \`Person\` object types. All fields are tested for equality and combined with a logical ‘and.’
+input PersonCondition {
+  # Checks for equality with the object’s \`about\` field.
+  about: String
+
+  # Checks for equality with the object’s \`createdAt\` field.
+  createdAt: Datetime
+
+  # Checks for equality with the object’s \`email\` field.
+  email: Email
+
+  # Checks for equality with the object’s \`name\` field.
+  name: String
+
+  # Checks for equality with the object’s \`rowId\` field.
+  rowId: Int
+}
+
+# An input for mutations affecting \`Person\`
+input PersonInput {
+  about: String
+  createdAt: Datetime
+  email: Email!
+
+  # The person’s name
+  name: String!
+  rowId: Int
+}
+
+# Represents an update to a \`Person\`. Fields that are set will be updated.
+input PersonPatch {
+  about: String
+  createdAt: Datetime
+  email: Email
+
+  # The person’s name
+  name: String
+  rowId: Int
+}
+
+type Post implements Node {
+  authorId: Int
+  body: String
+  headline: String!
+
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  id: ID!
+  rowId: Int!
+}
+
+# The root query type which gives access points into the data universe.
+type Query implements Node {
+  # Reads and enables pagination through a set of \`CompoundKey\`.
+  allCompoundKeys(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: CompoundKeyCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`CompoundKey\`.
+    orderBy: CompoundKeysOrderBy = PRIMARY_KEY_ASC
+  ): CompoundKeysConnection
+
+  # Reads and enables pagination through a set of \`EdgeCase\`.
+  allEdgeCases(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: EdgeCaseCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`EdgeCase\`.
+    orderBy: EdgeCasesOrderBy = NATURAL
+  ): EdgeCasesConnection
+
+  # Reads and enables pagination through a set of \`Person\`.
+  allPeople(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: PersonCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`Person\`.
+    orderBy: PeopleOrderBy = PRIMARY_KEY_ASC
+  ): PeopleConnection
+
+  # Reads a single \`CompoundKey\` using its globally unique \`ID\`.
+  compoundKey(
+    # The globally unique \`ID\` to be used in selecting a single \`CompoundKey\`.
+    id: ID!
+  ): CompoundKey
+  compoundKeyByPersonId1AndPersonId2(personId1: Int!, personId2: Int!): CompoundKey
+
+  # The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
+  id: ID!
+  intSetQuery(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+    x: Int
+    y: Int
+    z: Int
+  ): IntSetQueryConnection!
+  jsonIdentity(json: JSON): JSON
+  noArgsQuery: Int
+
+  # Fetches an object given its globally unique \`ID\`.
+  node(
+    # The globally unique \`ID\`.
+    id: ID!
+  ): Node
+
+  # Reads a single \`Person\` using its globally unique \`ID\`.
+  person(
+    # The globally unique \`ID\` to be used in selecting a single \`Person\`.
+    id: ID!
+  ): Person
+  personByEmail(email: Email!): Person
+  personByRowId(rowId: Int!): Person
+
+  # Exposes the root query type nested one level down. This is helpful for Relay 1
+  # which can only query top level fields if they are in a particular form.
+  query: Query!
+
+  # Reads and enables pagination through a set of \`Post\`.
+  tableQuery(id: Int): Post
+
+  # Reads and enables pagination through a set of \`Person\`.
+  tableSetQuery(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+  ): PeopleConnection!
+  typesQuery(a: BigInt!, b: Boolean!, c: String!, d: [Int]!, e: JSON!, f: FloatRangeInput!): Boolean
+}
+
+# All input for the \`tableMutation\` mutation.
+input TableMutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int
+}
+
+# The output of our \`tableMutation\` mutation.
+type TableMutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  post: Post
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`tableSetMutation\` mutation.
+input TableSetMutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+}
+
+# The output of our \`tableSetMutation\` mutation.
+type TableSetMutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  people: [Person]
+
+  # An edge for the type. May be used by Relay 1.
+  personEdge(
+    # The method to use when ordering \`Person\`.
+    orderBy: PeopleOrderBy = PRIMARY_KEY_ASC
+  ): PeopleEdge
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`typesMutation\` mutation.
+input TypesMutationInput {
+  a: BigInt!
+  b: Boolean!
+  c: String!
+
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  d: [Int]!
+  e: JSON!
+  f: FloatRangeInput!
+}
+
+# The output of our \`typesMutation\` mutation.
+type TypesMutationPayload {
+  boolean: Boolean
+
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`updateCompoundKeyByPersonId1AndPersonId2\` mutation.
+input UpdateCompoundKeyByPersonId1AndPersonId2Input {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # An object where the defined keys will be set on the \`CompoundKey\` being updated.
+  compoundKeyPatch: CompoundKeyPatch!
+  personId1: Int!
+  personId2: Int!
+}
+
+# All input for the \`updateCompoundKey\` mutation.
+input UpdateCompoundKeyInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # An object where the defined keys will be set on the \`CompoundKey\` being updated.
+  compoundKeyPatch: CompoundKeyPatch!
+
+  # The globally unique \`ID\` which will identify a single \`CompoundKey\` to be updated.
+  id: ID!
+}
+
+# The output of our update \`CompoundKey\` mutation.
+type UpdateCompoundKeyPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # The \`CompoundKey\` that was updated by this mutation.
+  compoundKey: CompoundKey
+
+  # An edge for the type. May be used by Relay 1.
+  compoundKeyEdge(
+    # The method to use when ordering \`CompoundKey\`.
+    orderBy: CompoundKeysOrderBy = PRIMARY_KEY_ASC
+  ): CompoundKeysEdge
+
+  # Reads a single \`Person\` that is related to this \`CompoundKey\`.
+  personByPersonId1: Person
+
+  # Reads a single \`Person\` that is related to this \`CompoundKey\`.
+  personByPersonId2: Person
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`updatePersonByEmail\` mutation.
+input UpdatePersonByEmailInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  email: Email!
+
+  # An object where the defined keys will be set on the \`Person\` being updated.
+  personPatch: PersonPatch!
+}
+
+# All input for the \`updatePersonByRowId\` mutation.
+input UpdatePersonByRowIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # An object where the defined keys will be set on the \`Person\` being updated.
+  personPatch: PersonPatch!
+  rowId: Int!
+}
+
+# All input for the \`updatePerson\` mutation.
+input UpdatePersonInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`Person\` to be updated.
+  id: ID!
+
+  # An object where the defined keys will be set on the \`Person\` being updated.
+  personPatch: PersonPatch!
+}
+
+# The output of our update \`Person\` mutation.
+type UpdatePersonPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # The \`Person\` that was updated by this mutation.
+  person: Person
+
+  # An edge for the type. May be used by Relay 1.
+  personEdge(
+    # The method to use when ordering \`Person\`.
+    orderBy: PeopleOrderBy = PRIMARY_KEY_ASC
+  ): PeopleEdge
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+"
+`;
+
+exports[`prints a schema with a JWT generating mutation 1`] = `
+"scalar AnInt
+
+# A range of \`AnInt\`.
+type AnIntRange {
+  # The ending bound of our range.
+  end: AnIntRangeBound
+
+  # The starting bound of our range.
+  start: AnIntRangeBound
+}
+
+# The value at one end of a range. A range can either include this value, or not.
+type AnIntRangeBound {
+  # Whether or not the value of this bound is included in the range.
+  inclusive: Boolean!
+
+  # The value at one end of our range.
+  value: AnInt!
+}
+
+# The value at one end of a range. A range can either include this value, or not.
+input AnIntRangeBoundInput {
+  # Whether or not the value of this bound is included in the range.
+  inclusive: Boolean!
+
+  # The value at one end of our range.
+  value: AnInt!
+}
+
+# A range of \`AnInt\`.
+input AnIntRangeInput {
+  # The ending bound of our range.
+  end: AnIntRangeBoundInput
+
+  # The starting bound of our range.
+  start: AnIntRangeBoundInput
+}
+
+scalar AnotherInt
+
+# All input for the \`authenticate\` mutation.
+input AuthenticateInput {
+  a: Int
+  b: Int
+  c: Int
+
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+}
+
+# All input for the \`authenticateMany\` mutation.
+input AuthenticateManyInput {
+  a: Int
+  b: Int
+  c: Int
+
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+}
+
+# The output of our \`authenticateMany\` mutation.
+type AuthenticateManyPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  jwtTokens: [JwtToken]
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# The output of our \`authenticate\` mutation.
+type AuthenticatePayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  jwtToken: JwtToken
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# A signed eight-byte integer. The upper big integer values are greater then the
+# max value for a JavaScript number. Therefore all big integers will be output as
+# strings and not numbers.
+scalar BigInt
+
+enum Color {
+  BLUE
+  GREEN
+  RED
+}
+
+# Awesome feature!
+type CompoundType {
+  a: Int
+  b: String
+  c: Color
+  d: UUID
+  fooBar: Int
+}
+
+# An input for mutations affecting \`CompoundType\`
+input CompoundTypeInput {
+  a: Int
+  b: String
+  c: Color
+  d: UUID
+  fooBar: Int
+}
+
+# All input for the \`compoundTypeMutation\` mutation.
+input CompoundTypeMutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  object: CompoundTypeInput
+}
+
+# The output of our \`compoundTypeMutation\` mutation.
+type CompoundTypeMutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  compoundType: CompoundType
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the create \`Type\` mutation.
+input CreateTypeInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The \`Type\` to be created by this mutation.
+  type: TypeInput!
+}
+
+# The output of our create \`Type\` mutation.
+type CreateTypePayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+
+  # The \`Type\` that was created by this mutation.
+  type: Type
+
+  # An edge for the type. May be used by Relay 1.
+  typeEdge(
+    # The method to use when ordering \`Type\`.
+    orderBy: TypesOrderBy = PRIMARY_KEY_ASC
+  ): TypesEdge
+}
+
+# All input for the create \`UpdatableView\` mutation.
+input CreateUpdatableViewInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The \`UpdatableView\` to be created by this mutation.
+  updatableView: UpdatableViewInput!
+}
+
+# The output of our create \`UpdatableView\` mutation.
+type CreateUpdatableViewPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+
+  # The \`UpdatableView\` that was created by this mutation.
+  updatableView: UpdatableView
+
+  # An edge for the type. May be used by Relay 1.
+  updatableViewEdge(
+    # The method to use when ordering \`UpdatableView\`.
+    orderBy: UpdatableViewsOrderBy = NATURAL
+  ): UpdatableViewsEdge
+}
+
+# A location in a connection that can be used for resuming pagination.
+scalar Cursor
+
+# The day, does not include a time.
+scalar Date
+
+# A range of \`Date\`.
+type DateRange {
+  # The ending bound of our range.
+  end: DateRangeBound
+
+  # The starting bound of our range.
+  start: DateRangeBound
+}
+
+# The value at one end of a range. A range can either include this value, or not.
+type DateRangeBound {
+  # Whether or not the value of this bound is included in the range.
+  inclusive: Boolean!
+
+  # The value at one end of our range.
+  value: Date!
+}
+
+# The value at one end of a range. A range can either include this value, or not.
+input DateRangeBoundInput {
+  # Whether or not the value of this bound is included in the range.
+  inclusive: Boolean!
+
+  # The value at one end of our range.
+  value: Date!
+}
+
+# A range of \`Date\`.
+input DateRangeInput {
+  # The ending bound of our range.
+  end: DateRangeBoundInput
+
+  # The starting bound of our range.
+  start: DateRangeBoundInput
+}
+
+# A point in time as described by the [ISO
+# 8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
+scalar Datetime
+
+# All input for the \`deleteTypeById\` mutation.
+input DeleteTypeByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+}
+
+# All input for the \`deleteType\` mutation.
+input DeleteTypeInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`Type\` to be deleted.
+  nodeId: ID!
+}
+
+# The output of our delete \`Type\` mutation.
+type DeleteTypePayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  deletedTypeId: ID
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+
+  # The \`Type\` that was deleted by this mutation.
+  type: Type
+
+  # An edge for the type. May be used by Relay 1.
+  typeEdge(
+    # The method to use when ordering \`Type\`.
+    orderBy: TypesOrderBy = PRIMARY_KEY_ASC
+  ): TypesEdge
+}
+
+# A range of \`Float\`.
+type FloatRange {
+  # The ending bound of our range.
+  end: FloatRangeBound
+
+  # The starting bound of our range.
+  start: FloatRangeBound
+}
+
+# The value at one end of a range. A range can either include this value, or not.
+type FloatRangeBound {
+  # Whether or not the value of this bound is included in the range.
+  inclusive: Boolean!
+
+  # The value at one end of our range.
+  value: Float!
+}
+
+# The value at one end of a range. A range can either include this value, or not.
+input FloatRangeBoundInput {
+  # Whether or not the value of this bound is included in the range.
+  inclusive: Boolean!
+
+  # The value at one end of our range.
+  value: Float!
+}
+
+# A range of \`Float\`.
+input FloatRangeInput {
+  # The ending bound of our range.
+  end: FloatRangeBoundInput
+
+  # The starting bound of our range.
+  start: FloatRangeBoundInput
+}
+
+# An interval of time that has passed where the smallest distinct unit is a second.
+type Interval {
+  # A quantity of days.
+  days: Int
+
+  # A quantity of hours.
+  hours: Int
+
+  # A quantity of minutes.
+  minutes: Int
+
+  # A quantity of months.
+  months: Int
+
+  # A quantity of seconds. This is the only non-integer field, as all the other
+  # fields will dump their overflow into a smaller unit of time. Intervals don’t
+  # have a smaller unit than seconds.
+  seconds: Float
+
+  # A quantity of years.
+  years: Int
+}
+
+# An interval of time that has passed where the smallest distinct unit is a second.
+input IntervalInput {
+  # A quantity of days.
+  days: Int
+
+  # A quantity of hours.
+  hours: Int
+
+  # A quantity of minutes.
+  minutes: Int
+
+  # A quantity of months.
+  months: Int
+
+  # A quantity of seconds. This is the only non-integer field, as all the other
+  # fields will dump their overflow into a smaller unit of time. Intervals don’t
+  # have a smaller unit than seconds.
+  seconds: Float
+
+  # A quantity of years.
+  years: Int
+}
+
+# A JavaScript object encoded in the JSON format as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+scalar JSON
+
+# A JSON Web Token defined by [RFC 7519](https://tools.ietf.org/html/rfc7519)
+# which securely represents claims between two parties.
+scalar JwtToken
+
+# All input for the \`mult1\` mutation.
+input Mult1Input {
+  arg0: Int
+  arg1: Int
+
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+}
+
+# The output of our \`mult1\` mutation.
+type Mult1Payload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  integer: Int
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`mult2\` mutation.
+input Mult2Input {
+  arg0: Int
+  arg1: Int
+
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+}
+
+# The output of our \`mult2\` mutation.
+type Mult2Payload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  integer: Int
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`mult3\` mutation.
+input Mult3Input {
+  arg0: Int!
+  arg1: Int!
+
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+}
+
+# The output of our \`mult3\` mutation.
+type Mult3Payload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  integer: Int
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`mult4\` mutation.
+input Mult4Input {
+  arg0: Int!
+  arg1: Int!
+
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+}
+
+# The output of our \`mult4\` mutation.
+type Mult4Payload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  integer: Int
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# The root mutation type which contains root level fields which mutate data.
+type Mutation {
+  authenticate(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: AuthenticateInput!
+  ): AuthenticatePayload!
+  authenticateMany(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: AuthenticateManyInput!
+  ): AuthenticateManyPayload!
+
+  # Reads and enables pagination through a set of \`CompoundType\`.
+  compoundTypeMutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CompoundTypeMutationInput!
+  ): CompoundTypeMutationPayload!
+
+  # Creates a single \`Type\`.
+  createType(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CreateTypeInput!
+  ): CreateTypePayload
+
+  # Creates a single \`UpdatableView\`.
+  createUpdatableView(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CreateUpdatableViewInput!
+  ): CreateUpdatableViewPayload
+
+  # Deletes a single \`Type\` using its globally unique id.
+  deleteType(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeleteTypeInput!
+  ): DeleteTypePayload
+
+  # Deletes a single \`Type\` using a unique key.
+  deleteTypeById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeleteTypeByIdInput!
+  ): DeleteTypePayload
+  mult1(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: Mult1Input!
+  ): Mult1Payload!
+  mult2(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: Mult2Input!
+  ): Mult2Payload!
+  mult3(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: Mult3Input!
+  ): Mult3Payload!
+  mult4(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: Mult4Input!
+  ): Mult4Payload!
+
+  # Updates a single \`Type\` using its globally unique id and a patch.
+  updateType(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdateTypeInput!
+  ): UpdateTypePayload
+
+  # Updates a single \`Type\` using a unique key and a patch.
+  updateTypeById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdateTypeByIdInput!
+  ): UpdateTypePayload
+}
+
+type NestedCompoundType {
+  a: CompoundType
+  b: CompoundType
+  bazBuz: Int
+}
+
+# An input for mutations affecting \`NestedCompoundType\`
+input NestedCompoundTypeInput {
+  a: CompoundTypeInput
+  b: CompoundTypeInput
+  bazBuz: Int
+}
+
+# An object with a globally unique \`ID\`.
+interface Node {
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  nodeId: ID!
+}
+
+# Information about pagination in a connection.
+type PageInfo {
+  # When paginating forwards, the cursor to continue.
+  endCursor: Cursor
+
+  # When paginating forwards, are there more items?
+  hasNextPage: Boolean!
+
+  # When paginating backwards, are there more items?
+  hasPreviousPage: Boolean!
+
+  # When paginating backwards, the cursor to continue.
+  startCursor: Cursor
+}
+
+# The root query type which gives access points into the data universe.
+type Query implements Node {
+  # Reads and enables pagination through a set of \`Type\`.
+  allTypes(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: TypeCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`Type\`.
+    orderBy: TypesOrderBy = PRIMARY_KEY_ASC
+  ): TypesConnection
+
+  # Reads and enables pagination through a set of \`UpdatableView\`.
+  allUpdatableViews(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: UpdatableViewCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`UpdatableView\`.
+    orderBy: UpdatableViewsOrderBy = NATURAL
+  ): UpdatableViewsConnection
+
+  # Reads and enables pagination through a set of \`CompoundType\`.
+  compoundTypeQuery(object: CompoundTypeInput): CompoundType
+
+  # Fetches an object given its globally unique \`ID\`.
+  node(
+    # The globally unique \`ID\`.
+    nodeId: ID!
+  ): Node
+
+  # The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
+  nodeId: ID!
+
+  # Exposes the root query type nested one level down. This is helpful for Relay 1
+  # which can only query top level fields if they are in a particular form.
+  query: Query!
+
+  # Reads a single \`Type\` using its globally unique \`ID\`.
+  type(
+    # The globally unique \`ID\` to be used in selecting a single \`Type\`.
+    nodeId: ID!
+  ): Type
+  typeById(id: Int!): Type
+}
+
+# The exact time of day, does not include the date. May or may not have a timezone offset.
+scalar Time
+
+type Type implements Node {
+  anIntRange: AnIntRange!
+  bigint: BigInt!
+  boolean: Boolean!
+  compoundType: CompoundType!
+  date: Date!
+  daterange: DateRange!
+  decimal: Float!
+  domain: AnInt!
+  domain2: AnotherInt!
+  enum: Color!
+  enumArray: [Color]!
+  id: Int!
+  interval: Interval!
+  json: JSON!
+  jsonb: JSON!
+  money: Float!
+  nestedCompoundType: NestedCompoundType!
+
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  nodeId: ID!
+  nullableRange: FloatRange
+  numeric: Float!
+  numrange: FloatRange!
+  smallint: Int!
+  textArray: [String]!
+  time: Time!
+  timestamp: Datetime!
+  timestamptz: Datetime!
+  timetz: Time!
+  varchar: String!
+}
+
+# A condition to be used against \`Type\` object types. All fields are tested for equality and combined with a logical ‘and.’
+input TypeCondition {
+  # Checks for equality with the object’s \`anIntRange\` field.
+  anIntRange: AnIntRangeInput
+
+  # Checks for equality with the object’s \`bigint\` field.
+  bigint: BigInt
+
+  # Checks for equality with the object’s \`boolean\` field.
+  boolean: Boolean
+
+  # Checks for equality with the object’s \`compoundType\` field.
+  compoundType: CompoundTypeInput
+
+  # Checks for equality with the object’s \`date\` field.
+  date: Date
+
+  # Checks for equality with the object’s \`daterange\` field.
+  daterange: DateRangeInput
+
+  # Checks for equality with the object’s \`decimal\` field.
+  decimal: Float
+
+  # Checks for equality with the object’s \`domain\` field.
+  domain: AnInt
+
+  # Checks for equality with the object’s \`domain2\` field.
+  domain2: AnotherInt
+
+  # Checks for equality with the object’s \`enum\` field.
+  enum: Color
+
+  # Checks for equality with the object’s \`enumArray\` field.
+  enumArray: [Color]
+
+  # Checks for equality with the object’s \`id\` field.
+  id: Int
+
+  # Checks for equality with the object’s \`interval\` field.
+  interval: IntervalInput
+
+  # Checks for equality with the object’s \`json\` field.
+  json: JSON
+
+  # Checks for equality with the object’s \`jsonb\` field.
+  jsonb: JSON
+
+  # Checks for equality with the object’s \`money\` field.
+  money: Float
+
+  # Checks for equality with the object’s \`nestedCompoundType\` field.
+  nestedCompoundType: NestedCompoundTypeInput
+
+  # Checks for equality with the object’s \`nullableRange\` field.
+  nullableRange: FloatRangeInput
+
+  # Checks for equality with the object’s \`numeric\` field.
+  numeric: Float
+
+  # Checks for equality with the object’s \`numrange\` field.
+  numrange: FloatRangeInput
+
+  # Checks for equality with the object’s \`smallint\` field.
+  smallint: Int
+
+  # Checks for equality with the object’s \`textArray\` field.
+  textArray: [String]
+
+  # Checks for equality with the object’s \`time\` field.
+  time: Time
+
+  # Checks for equality with the object’s \`timestamp\` field.
+  timestamp: Datetime
+
+  # Checks for equality with the object’s \`timestamptz\` field.
+  timestamptz: Datetime
+
+  # Checks for equality with the object’s \`timetz\` field.
+  timetz: Time
+
+  # Checks for equality with the object’s \`varchar\` field.
+  varchar: String
+}
+
+# An input for mutations affecting \`Type\`
+input TypeInput {
+  anIntRange: AnIntRangeInput!
+  bigint: BigInt!
+  boolean: Boolean!
+  compoundType: CompoundTypeInput!
+  date: Date!
+  daterange: DateRangeInput!
+  decimal: Float!
+  domain: AnInt!
+  domain2: AnotherInt!
+  enum: Color!
+  enumArray: [Color]!
+  id: Int
+  interval: IntervalInput!
+  json: JSON!
+  jsonb: JSON!
+  money: Float!
+  nestedCompoundType: NestedCompoundTypeInput!
+  nullableRange: FloatRangeInput
+  numeric: Float!
+  numrange: FloatRangeInput!
+  smallint: Int!
+  textArray: [String]!
+  time: Time!
+  timestamp: Datetime!
+  timestamptz: Datetime!
+  timetz: Time!
+  varchar: String!
+}
+
+# Represents an update to a \`Type\`. Fields that are set will be updated.
+input TypePatch {
+  anIntRange: AnIntRangeInput
+  bigint: BigInt
+  boolean: Boolean
+  compoundType: CompoundTypeInput
+  date: Date
+  daterange: DateRangeInput
+  decimal: Float
+  domain: AnInt
+  domain2: AnotherInt
+  enum: Color
+  enumArray: [Color]
+  id: Int
+  interval: IntervalInput
+  json: JSON
+  jsonb: JSON
+  money: Float
+  nestedCompoundType: NestedCompoundTypeInput
+  nullableRange: FloatRangeInput
+  numeric: Float
+  numrange: FloatRangeInput
+  smallint: Int
+  textArray: [String]
+  time: Time
+  timestamp: Datetime
+  timestamptz: Datetime
+  timetz: Time
+  varchar: String
+}
+
+# A connection to a list of \`Type\` values.
+type TypesConnection {
+  # A list of edges which contains the \`Type\` and cursor to aid in pagination.
+  edges: [TypesEdge!]!
+
+  # A list of \`Type\` objects.
+  nodes: [Type]!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`Type\` you could get from the connection.
+  totalCount: Int
+}
+
+# A \`Type\` edge in the connection.
+type TypesEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`Type\` at the end of the edge.
+  node: Type!
+}
+
+# Methods to use when ordering \`Type\`.
+enum TypesOrderBy {
+  AN_INT_RANGE_ASC
+  AN_INT_RANGE_DESC
+  BIGINT_ASC
+  BIGINT_DESC
+  BOOLEAN_ASC
+  BOOLEAN_DESC
+  COMPOUND_TYPE_ASC
+  COMPOUND_TYPE_DESC
+  DATE_ASC
+  DATE_DESC
+  DATERANGE_ASC
+  DATERANGE_DESC
+  DECIMAL_ASC
+  DECIMAL_DESC
+  DOMAIN_ASC
+  DOMAIN_DESC
+  DOMAIN2_ASC
+  DOMAIN2_DESC
+  ENUM_ARRAY_ASC
+  ENUM_ARRAY_DESC
+  ENUM_ASC
+  ENUM_DESC
+  ID_ASC
+  ID_DESC
+  INTERVAL_ASC
+  INTERVAL_DESC
+  JSON_ASC
+  JSON_DESC
+  JSONB_ASC
+  JSONB_DESC
+  MONEY_ASC
+  MONEY_DESC
+  NATURAL
+  NESTED_COMPOUND_TYPE_ASC
+  NESTED_COMPOUND_TYPE_DESC
+  NULLABLE_RANGE_ASC
+  NULLABLE_RANGE_DESC
+  NUMERIC_ASC
+  NUMERIC_DESC
+  NUMRANGE_ASC
+  NUMRANGE_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  SMALLINT_ASC
+  SMALLINT_DESC
+  TEXT_ARRAY_ASC
+  TEXT_ARRAY_DESC
+  TIME_ASC
+  TIME_DESC
+  TIMESTAMP_ASC
+  TIMESTAMP_DESC
+  TIMESTAMPTZ_ASC
+  TIMESTAMPTZ_DESC
+  TIMETZ_ASC
+  TIMETZ_DESC
+  VARCHAR_ASC
+  VARCHAR_DESC
+}
+
+# YOYOYO!!
+type UpdatableView implements Node {
+  # This is constantly 2
+  constant: Int
+  description: String
+  name: String
+
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  nodeId: ID!
+  x: Int
+}
+
+# A condition to be used against \`UpdatableView\` object types. All fields are
+# tested for equality and combined with a logical ‘and.’
+input UpdatableViewCondition {
+  # Checks for equality with the object’s \`constant\` field.
+  constant: Int
+
+  # Checks for equality with the object’s \`description\` field.
+  description: String
+
+  # Checks for equality with the object’s \`name\` field.
+  name: String
+
+  # Checks for equality with the object’s \`x\` field.
+  x: Int
+}
+
+# An input for mutations affecting \`UpdatableView\`
+input UpdatableViewInput {
+  # This is constantly 2
+  constant: Int
+  description: String
+  name: String
+  x: Int
+}
+
+# A connection to a list of \`UpdatableView\` values.
+type UpdatableViewsConnection {
+  # A list of edges which contains the \`UpdatableView\` and cursor to aid in pagination.
+  edges: [UpdatableViewsEdge!]!
+
+  # A list of \`UpdatableView\` objects.
+  nodes: [UpdatableView]!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`UpdatableView\` you could get from the connection.
+  totalCount: Int
+}
+
+# A \`UpdatableView\` edge in the connection.
+type UpdatableViewsEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`UpdatableView\` at the end of the edge.
+  node: UpdatableView!
+}
+
+# Methods to use when ordering \`UpdatableView\`.
+enum UpdatableViewsOrderBy {
+  CONSTANT_ASC
+  CONSTANT_DESC
+  DESCRIPTION_ASC
+  DESCRIPTION_DESC
+  NAME_ASC
+  NAME_DESC
+  NATURAL
+  X_ASC
+  X_DESC
+}
+
+# All input for the \`updateTypeById\` mutation.
+input UpdateTypeByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+
+  # An object where the defined keys will be set on the \`Type\` being updated.
+  typePatch: TypePatch!
+}
+
+# All input for the \`updateType\` mutation.
+input UpdateTypeInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`Type\` to be updated.
+  nodeId: ID!
+
+  # An object where the defined keys will be set on the \`Type\` being updated.
+  typePatch: TypePatch!
+}
+
+# The output of our update \`Type\` mutation.
+type UpdateTypePayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+
+  # The \`Type\` that was updated by this mutation.
+  type: Type
+
+  # An edge for the type. May be used by Relay 1.
+  typeEdge(
+    # The method to use when ordering \`Type\`.
+    orderBy: TypesOrderBy = PRIMARY_KEY_ASC
+  ): TypesEdge
+}
+
+# A universally unique identifier as defined by [RFC 4122](https://tools.ietf.org/html/rfc4122).
+scalar UUID
+"
+`;
+
+exports[`prints a schema with the default options 1`] = `
+"# All input for the \`add1Mutation\` mutation.
+input Add1MutationInput {
+  arg0: Int!
+  arg1: Int!
+
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+}
+
+# The output of our \`add1Mutation\` mutation.
+type Add1MutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  integer: Int
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`add2Mutation\` mutation.
+input Add2MutationInput {
+  a: Int!
+  b: Int!
+
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+}
+
+# The output of our \`add2Mutation\` mutation.
+type Add2MutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  integer: Int
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`add3Mutation\` mutation.
+input Add3MutationInput {
+  a: Int
+  arg1: Int
+
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+}
+
+# The output of our \`add3Mutation\` mutation.
+type Add3MutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  integer: Int
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`add4Mutation\` mutation.
+input Add4MutationInput {
+  arg0: Int
+  b: Int
+
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+}
+
+# The output of our \`add4Mutation\` mutation.
+type Add4MutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  integer: Int
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+scalar AnInt
+
+# A range of \`AnInt\`.
+type AnIntRange {
+  # The ending bound of our range.
+  end: AnIntRangeBound
+
+  # The starting bound of our range.
+  start: AnIntRangeBound
+}
+
+# The value at one end of a range. A range can either include this value, or not.
+type AnIntRangeBound {
+  # Whether or not the value of this bound is included in the range.
+  inclusive: Boolean!
+
+  # The value at one end of our range.
+  value: AnInt!
+}
+
+# The value at one end of a range. A range can either include this value, or not.
+input AnIntRangeBoundInput {
+  # Whether or not the value of this bound is included in the range.
+  inclusive: Boolean!
+
+  # The value at one end of our range.
+  value: AnInt!
+}
+
+# A range of \`AnInt\`.
+input AnIntRangeInput {
+  # The ending bound of our range.
+  end: AnIntRangeBoundInput
+
+  # The starting bound of our range.
+  start: AnIntRangeBoundInput
+}
+
+scalar AnotherInt
+
+# All input for the \`authenticate\` mutation.
+input AuthenticateInput {
+  a: Int
+  b: Int
+  c: Int
+
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+}
+
+# All input for the \`authenticateMany\` mutation.
+input AuthenticateManyInput {
+  a: Int
+  b: Int
+  c: Int
+
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+}
+
+# The output of our \`authenticateMany\` mutation.
+type AuthenticateManyPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  jwtTokens: [JwtToken]
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# The output of our \`authenticate\` mutation.
+type AuthenticatePayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  jwtToken: JwtToken
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# A signed eight-byte integer. The upper big integer values are greater then the
+# max value for a JavaScript number. Therefore all big integers will be output as
+# strings and not numbers.
+scalar BigInt
+
+enum Color {
+  BLUE
+  GREEN
+  RED
+}
+
+type CompoundKey implements Node {
+  extra: Boolean
+
+  # Reads and enables pagination through a set of \`ForeignKey\`.
+  foreignKeysByCompoundKey1AndCompoundKey2(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: ForeignKeyCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`ForeignKey\`.
+    orderBy: ForeignKeysOrderBy = NATURAL
+  ): ForeignKeysConnection!
+
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  nodeId: ID!
+
+  # Reads a single \`Person\` that is related to this \`CompoundKey\`.
+  personByPersonId1: Person!
+
+  # Reads a single \`Person\` that is related to this \`CompoundKey\`.
+  personByPersonId2: Person!
+  personId1: Int!
+  personId2: Int!
+}
+
+# A condition to be used against \`CompoundKey\` object types. All fields are tested
+# for equality and combined with a logical ‘and.’
+input CompoundKeyCondition {
+  # Checks for equality with the object’s \`extra\` field.
+  extra: Boolean
+
+  # Checks for equality with the object’s \`personId1\` field.
+  personId1: Int
+
+  # Checks for equality with the object’s \`personId2\` field.
+  personId2: Int
+}
+
+# An input for mutations affecting \`CompoundKey\`
+input CompoundKeyInput {
+  extra: Boolean
+  personId1: Int!
+  personId2: Int!
+}
+
+# Represents an update to a \`CompoundKey\`. Fields that are set will be updated.
+input CompoundKeyPatch {
+  extra: Boolean
+  personId1: Int
+  personId2: Int
+}
+
+# A connection to a list of \`CompoundKey\` values.
+type CompoundKeysConnection {
+  # A list of edges which contains the \`CompoundKey\` and cursor to aid in pagination.
+  edges: [CompoundKeysEdge!]!
+
+  # A list of \`CompoundKey\` objects.
+  nodes: [CompoundKey]!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`CompoundKey\` you could get from the connection.
+  totalCount: Int
+}
+
+# A \`CompoundKey\` edge in the connection.
+type CompoundKeysEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`CompoundKey\` at the end of the edge.
+  node: CompoundKey!
+}
+
+# Methods to use when ordering \`CompoundKey\`.
+enum CompoundKeysOrderBy {
+  EXTRA_ASC
+  EXTRA_DESC
+  NATURAL
+  PERSON_ID_1_ASC
+  PERSON_ID_1_DESC
+  PERSON_ID_2_ASC
+  PERSON_ID_2_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+# Awesome feature!
+type CompoundType {
+  a: Int
+  b: String
+  c: Color
+  computedField: Int
+  d: UUID
+  fooBar: Int
+}
+
+# An input for mutations affecting \`CompoundType\`
+input CompoundTypeInput {
+  a: Int
+  b: String
+  c: Color
+  d: UUID
+  fooBar: Int
+}
+
+# All input for the \`compoundTypeMutation\` mutation.
+input CompoundTypeMutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  object: CompoundTypeInput
+}
+
+# The output of our \`compoundTypeMutation\` mutation.
+type CompoundTypeMutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  compoundType: CompoundType
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the create \`CompoundKey\` mutation.
+input CreateCompoundKeyInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The \`CompoundKey\` to be created by this mutation.
+  compoundKey: CompoundKeyInput!
+}
+
+# The output of our create \`CompoundKey\` mutation.
+type CreateCompoundKeyPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # The \`CompoundKey\` that was created by this mutation.
+  compoundKey: CompoundKey
+
+  # An edge for the type. May be used by Relay 1.
+  compoundKeyEdge(
+    # The method to use when ordering \`CompoundKey\`.
+    orderBy: CompoundKeysOrderBy = PRIMARY_KEY_ASC
+  ): CompoundKeysEdge
+
+  # Reads a single \`Person\` that is related to this \`CompoundKey\`.
+  personByPersonId1: Person
+
+  # Reads a single \`Person\` that is related to this \`CompoundKey\`.
+  personByPersonId2: Person
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the create \`EdgeCase\` mutation.
+input CreateEdgeCaseInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The \`EdgeCase\` to be created by this mutation.
+  edgeCase: EdgeCaseInput!
+}
+
+# The output of our create \`EdgeCase\` mutation.
+type CreateEdgeCasePayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # The \`EdgeCase\` that was created by this mutation.
+  edgeCase: EdgeCase
+
+  # An edge for the type. May be used by Relay 1.
+  edgeCaseEdge(
+    # The method to use when ordering \`EdgeCase\`.
+    orderBy: EdgeCasesOrderBy = NATURAL
+  ): EdgeCasesEdge
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the create \`ForeignKey\` mutation.
+input CreateForeignKeyInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The \`ForeignKey\` to be created by this mutation.
+  foreignKey: ForeignKeyInput!
+}
+
+# The output of our create \`ForeignKey\` mutation.
+type CreateForeignKeyPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # Reads a single \`CompoundKey\` that is related to this \`ForeignKey\`.
+  compoundKeyByCompoundKey1AndCompoundKey2: CompoundKey
+
+  # The \`ForeignKey\` that was created by this mutation.
+  foreignKey: ForeignKey
+
+  # An edge for the type. May be used by Relay 1.
+  foreignKeyEdge(
+    # The method to use when ordering \`ForeignKey\`.
+    orderBy: ForeignKeysOrderBy = NATURAL
+  ): ForeignKeysEdge
+
+  # Reads a single \`Person\` that is related to this \`ForeignKey\`.
+  personByPersonId: Person
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the create \`Person\` mutation.
+input CreatePersonInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The \`Person\` to be created by this mutation.
+  person: PersonInput!
+}
+
+# The output of our create \`Person\` mutation.
+type CreatePersonPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # The \`Person\` that was created by this mutation.
+  person: Person
+
+  # An edge for the type. May be used by Relay 1.
+  personEdge(
+    # The method to use when ordering \`Person\`.
+    orderBy: PeopleOrderBy = PRIMARY_KEY_ASC
+  ): PeopleEdge
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the create \`Post\` mutation.
+input CreatePostInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The \`Post\` to be created by this mutation.
+  post: PostInput!
+}
+
+# The output of our create \`Post\` mutation.
+type CreatePostPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # Reads a single \`Person\` that is related to this \`Post\`.
+  personByAuthorId: Person
+
+  # The \`Post\` that was created by this mutation.
+  post: Post
+
+  # An edge for the type. May be used by Relay 1.
+  postEdge(
+    # The method to use when ordering \`Post\`.
+    orderBy: PostsOrderBy = PRIMARY_KEY_ASC
+  ): PostsEdge
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the create \`SimilarTable1\` mutation.
+input CreateSimilarTable1Input {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The \`SimilarTable1\` to be created by this mutation.
+  similarTable1: SimilarTable1Input!
+}
+
+# The output of our create \`SimilarTable1\` mutation.
+type CreateSimilarTable1Payload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+
+  # The \`SimilarTable1\` that was created by this mutation.
+  similarTable1: SimilarTable1
+
+  # An edge for the type. May be used by Relay 1.
+  similarTable1Edge(
+    # The method to use when ordering \`SimilarTable1\`.
+    orderBy: SimilarTable1SOrderBy = PRIMARY_KEY_ASC
+  ): SimilarTable1SEdge
+}
+
+# All input for the create \`SimilarTable2\` mutation.
+input CreateSimilarTable2Input {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The \`SimilarTable2\` to be created by this mutation.
+  similarTable2: SimilarTable2Input!
+}
+
+# The output of our create \`SimilarTable2\` mutation.
+type CreateSimilarTable2Payload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+
+  # The \`SimilarTable2\` that was created by this mutation.
+  similarTable2: SimilarTable2
+
+  # An edge for the type. May be used by Relay 1.
+  similarTable2Edge(
+    # The method to use when ordering \`SimilarTable2\`.
+    orderBy: SimilarTable2SOrderBy = PRIMARY_KEY_ASC
+  ): SimilarTable2SEdge
+}
+
+# All input for the create \`Type\` mutation.
+input CreateTypeInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The \`Type\` to be created by this mutation.
+  type: TypeInput!
+}
+
+# The output of our create \`Type\` mutation.
+type CreateTypePayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+
+  # The \`Type\` that was created by this mutation.
+  type: Type
+
+  # An edge for the type. May be used by Relay 1.
+  typeEdge(
+    # The method to use when ordering \`Type\`.
+    orderBy: TypesOrderBy = PRIMARY_KEY_ASC
+  ): TypesEdge
+}
+
+# All input for the create \`UpdatableView\` mutation.
+input CreateUpdatableViewInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The \`UpdatableView\` to be created by this mutation.
+  updatableView: UpdatableViewInput!
+}
+
+# The output of our create \`UpdatableView\` mutation.
+type CreateUpdatableViewPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+
+  # The \`UpdatableView\` that was created by this mutation.
+  updatableView: UpdatableView
+
+  # An edge for the type. May be used by Relay 1.
+  updatableViewEdge(
+    # The method to use when ordering \`UpdatableView\`.
+    orderBy: UpdatableViewsOrderBy = NATURAL
+  ): UpdatableViewsEdge
+}
+
+# A location in a connection that can be used for resuming pagination.
+scalar Cursor
+
+# The day, does not include a time.
+scalar Date
+
+# A range of \`Date\`.
+type DateRange {
+  # The ending bound of our range.
+  end: DateRangeBound
+
+  # The starting bound of our range.
+  start: DateRangeBound
+}
+
+# The value at one end of a range. A range can either include this value, or not.
+type DateRangeBound {
+  # Whether or not the value of this bound is included in the range.
+  inclusive: Boolean!
+
+  # The value at one end of our range.
+  value: Date!
+}
+
+# The value at one end of a range. A range can either include this value, or not.
+input DateRangeBoundInput {
+  # Whether or not the value of this bound is included in the range.
+  inclusive: Boolean!
+
+  # The value at one end of our range.
+  value: Date!
+}
+
+# A range of \`Date\`.
+input DateRangeInput {
+  # The ending bound of our range.
+  end: DateRangeBoundInput
+
+  # The starting bound of our range.
+  start: DateRangeBoundInput
+}
+
+# A point in time as described by the [ISO
+# 8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
+scalar Datetime
+
+# All input for the \`deleteCompoundKeyByPersonId1AndPersonId2\` mutation.
+input DeleteCompoundKeyByPersonId1AndPersonId2Input {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  personId1: Int!
+  personId2: Int!
+}
+
+# All input for the \`deleteCompoundKey\` mutation.
+input DeleteCompoundKeyInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`CompoundKey\` to be deleted.
+  nodeId: ID!
+}
+
+# The output of our delete \`CompoundKey\` mutation.
+type DeleteCompoundKeyPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # The \`CompoundKey\` that was deleted by this mutation.
+  compoundKey: CompoundKey
+
+  # An edge for the type. May be used by Relay 1.
+  compoundKeyEdge(
+    # The method to use when ordering \`CompoundKey\`.
+    orderBy: CompoundKeysOrderBy = PRIMARY_KEY_ASC
+  ): CompoundKeysEdge
+  deletedCompoundKeyId: ID
+
+  # Reads a single \`Person\` that is related to this \`CompoundKey\`.
+  personByPersonId1: Person
+
+  # Reads a single \`Person\` that is related to this \`CompoundKey\`.
+  personByPersonId2: Person
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`deletePersonByEmail\` mutation.
+input DeletePersonByEmailInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  email: Email!
+}
+
+# All input for the \`deletePersonById\` mutation.
+input DeletePersonByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+}
+
+# All input for the \`deletePerson\` mutation.
+input DeletePersonInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`Person\` to be deleted.
+  nodeId: ID!
+}
+
+# The output of our delete \`Person\` mutation.
+type DeletePersonPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  deletedPersonId: ID
+
+  # The \`Person\` that was deleted by this mutation.
+  person: Person
+
+  # An edge for the type. May be used by Relay 1.
+  personEdge(
+    # The method to use when ordering \`Person\`.
+    orderBy: PeopleOrderBy = PRIMARY_KEY_ASC
+  ): PeopleEdge
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`deletePostById\` mutation.
+input DeletePostByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+}
+
+# All input for the \`deletePost\` mutation.
+input DeletePostInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`Post\` to be deleted.
+  nodeId: ID!
+}
+
+# The output of our delete \`Post\` mutation.
+type DeletePostPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  deletedPostId: ID
+
+  # Reads a single \`Person\` that is related to this \`Post\`.
+  personByAuthorId: Person
+
+  # The \`Post\` that was deleted by this mutation.
+  post: Post
+
+  # An edge for the type. May be used by Relay 1.
+  postEdge(
+    # The method to use when ordering \`Post\`.
+    orderBy: PostsOrderBy = PRIMARY_KEY_ASC
+  ): PostsEdge
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`deleteSimilarTable1ById\` mutation.
+input DeleteSimilarTable1ByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+}
+
+# All input for the \`deleteSimilarTable1\` mutation.
+input DeleteSimilarTable1Input {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`SimilarTable1\` to be deleted.
+  nodeId: ID!
+}
+
+# The output of our delete \`SimilarTable1\` mutation.
+type DeleteSimilarTable1Payload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  deletedSimilarTable1Id: ID
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+
+  # The \`SimilarTable1\` that was deleted by this mutation.
+  similarTable1: SimilarTable1
+
+  # An edge for the type. May be used by Relay 1.
+  similarTable1Edge(
+    # The method to use when ordering \`SimilarTable1\`.
+    orderBy: SimilarTable1SOrderBy = PRIMARY_KEY_ASC
+  ): SimilarTable1SEdge
+}
+
+# All input for the \`deleteSimilarTable2ById\` mutation.
+input DeleteSimilarTable2ByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+}
+
+# All input for the \`deleteSimilarTable2\` mutation.
+input DeleteSimilarTable2Input {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`SimilarTable2\` to be deleted.
+  nodeId: ID!
+}
+
+# The output of our delete \`SimilarTable2\` mutation.
+type DeleteSimilarTable2Payload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  deletedSimilarTable2Id: ID
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+
+  # The \`SimilarTable2\` that was deleted by this mutation.
+  similarTable2: SimilarTable2
+
+  # An edge for the type. May be used by Relay 1.
+  similarTable2Edge(
+    # The method to use when ordering \`SimilarTable2\`.
+    orderBy: SimilarTable2SOrderBy = PRIMARY_KEY_ASC
+  ): SimilarTable2SEdge
+}
+
+# All input for the \`deleteTypeById\` mutation.
+input DeleteTypeByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+}
+
+# All input for the \`deleteType\` mutation.
+input DeleteTypeInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`Type\` to be deleted.
+  nodeId: ID!
+}
+
+# The output of our delete \`Type\` mutation.
+type DeleteTypePayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  deletedTypeId: ID
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+
+  # The \`Type\` that was deleted by this mutation.
+  type: Type
+
+  # An edge for the type. May be used by Relay 1.
+  typeEdge(
+    # The method to use when ordering \`Type\`.
+    orderBy: TypesOrderBy = PRIMARY_KEY_ASC
+  ): TypesEdge
+}
+
+type EdgeCase implements Node {
+  computed: String
+
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  nodeId: ID!
+  notNullHasDefault: Boolean!
+  rowId: Int
+  wontCastEasy: Int
+}
+
+# A condition to be used against \`EdgeCase\` object types. All fields are tested
+# for equality and combined with a logical ‘and.’
+input EdgeCaseCondition {
+  # Checks for equality with the object’s \`notNullHasDefault\` field.
+  notNullHasDefault: Boolean
+
+  # Checks for equality with the object’s \`rowId\` field.
+  rowId: Int
+
+  # Checks for equality with the object’s \`wontCastEasy\` field.
+  wontCastEasy: Int
+}
+
+# An input for mutations affecting \`EdgeCase\`
+input EdgeCaseInput {
+  notNullHasDefault: Boolean
+  rowId: Int
+  wontCastEasy: Int
+}
+
+# A connection to a list of \`EdgeCase\` values.
+type EdgeCasesConnection {
+  # A list of edges which contains the \`EdgeCase\` and cursor to aid in pagination.
+  edges: [EdgeCasesEdge!]!
+
+  # A list of \`EdgeCase\` objects.
+  nodes: [EdgeCase]!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`EdgeCase\` you could get from the connection.
+  totalCount: Int
+}
+
+# A \`EdgeCase\` edge in the connection.
+type EdgeCasesEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`EdgeCase\` at the end of the edge.
+  node: EdgeCase!
+}
+
+# Methods to use when ordering \`EdgeCase\`.
+enum EdgeCasesOrderBy {
+  NATURAL
+  NOT_NULL_HAS_DEFAULT_ASC
+  NOT_NULL_HAS_DEFAULT_DESC
+  ROW_ID_ASC
+  ROW_ID_DESC
+  WONT_CAST_EASY_ASC
+  WONT_CAST_EASY_DESC
+}
+
+scalar Email
+
+# A range of \`Float\`.
+type FloatRange {
+  # The ending bound of our range.
+  end: FloatRangeBound
+
+  # The starting bound of our range.
+  start: FloatRangeBound
+}
+
+# The value at one end of a range. A range can either include this value, or not.
+type FloatRangeBound {
+  # Whether or not the value of this bound is included in the range.
+  inclusive: Boolean!
+
+  # The value at one end of our range.
+  value: Float!
+}
+
+# The value at one end of a range. A range can either include this value, or not.
+input FloatRangeBoundInput {
+  # Whether or not the value of this bound is included in the range.
+  inclusive: Boolean!
+
+  # The value at one end of our range.
+  value: Float!
+}
+
+# A range of \`Float\`.
+input FloatRangeInput {
+  # The ending bound of our range.
+  end: FloatRangeBoundInput
+
+  # The starting bound of our range.
+  start: FloatRangeBoundInput
+}
+
+type ForeignKey implements Node {
+  compoundKey1: Int
+  compoundKey2: Int
+
+  # Reads a single \`CompoundKey\` that is related to this \`ForeignKey\`.
+  compoundKeyByCompoundKey1AndCompoundKey2: CompoundKey
+
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  nodeId: ID!
+
+  # Reads a single \`Person\` that is related to this \`ForeignKey\`.
+  personByPersonId: Person
+  personId: Int
+}
+
+# A condition to be used against \`ForeignKey\` object types. All fields are tested
+# for equality and combined with a logical ‘and.’
+input ForeignKeyCondition {
+  # Checks for equality with the object’s \`compoundKey1\` field.
+  compoundKey1: Int
+
+  # Checks for equality with the object’s \`compoundKey2\` field.
+  compoundKey2: Int
+
+  # Checks for equality with the object’s \`personId\` field.
+  personId: Int
+}
+
+# An input for mutations affecting \`ForeignKey\`
+input ForeignKeyInput {
+  compoundKey1: Int
+  compoundKey2: Int
+  personId: Int
+}
+
+# A connection to a list of \`ForeignKey\` values.
+type ForeignKeysConnection {
+  # A list of edges which contains the \`ForeignKey\` and cursor to aid in pagination.
+  edges: [ForeignKeysEdge!]!
+
+  # A list of \`ForeignKey\` objects.
+  nodes: [ForeignKey]!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`ForeignKey\` you could get from the connection.
+  totalCount: Int
+}
+
+# A \`ForeignKey\` edge in the connection.
+type ForeignKeysEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`ForeignKey\` at the end of the edge.
+  node: ForeignKey!
+}
+
+# Methods to use when ordering \`ForeignKey\`.
+enum ForeignKeysOrderBy {
+  COMPOUND_KEY_1_ASC
+  COMPOUND_KEY_1_DESC
+  COMPOUND_KEY_2_ASC
+  COMPOUND_KEY_2_DESC
+  NATURAL
+  PERSON_ID_ASC
+  PERSON_ID_DESC
+}
+
+# An interval of time that has passed where the smallest distinct unit is a second.
+type Interval {
+  # A quantity of days.
+  days: Int
+
+  # A quantity of hours.
+  hours: Int
+
+  # A quantity of minutes.
+  minutes: Int
+
+  # A quantity of months.
+  months: Int
+
+  # A quantity of seconds. This is the only non-integer field, as all the other
+  # fields will dump their overflow into a smaller unit of time. Intervals don’t
+  # have a smaller unit than seconds.
+  seconds: Float
+
+  # A quantity of years.
+  years: Int
+}
+
+# An interval of time that has passed where the smallest distinct unit is a second.
+input IntervalInput {
+  # A quantity of days.
+  days: Int
+
+  # A quantity of hours.
+  hours: Int
+
+  # A quantity of minutes.
+  minutes: Int
+
+  # A quantity of months.
+  months: Int
+
+  # A quantity of seconds. This is the only non-integer field, as all the other
+  # fields will dump their overflow into a smaller unit of time. Intervals don’t
+  # have a smaller unit than seconds.
+  seconds: Float
+
+  # A quantity of years.
+  years: Int
+}
+
+# All input for the \`intSetMutation\` mutation.
+input IntSetMutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  x: Int
+  y: Int
+  z: Int
+}
+
+# The output of our \`intSetMutation\` mutation.
+type IntSetMutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  integers: [Int]
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# A connection to a list of \`Int\` values.
+type IntSetQueryConnection {
+  # A list of edges which contains the \`Int\` and cursor to aid in pagination.
+  edges: [IntSetQueryEdge!]!
+
+  # A list of \`Int\` objects.
+  nodes: [Int]!
+}
+
+# A \`Int\` edge in the connection.
+type IntSetQueryEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`Int\` at the end of the edge.
+  node: Int
+}
+
+# A JavaScript object encoded in the JSON format as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+scalar JSON
+
+# All input for the \`jsonIdentityMutation\` mutation.
+input JsonIdentityMutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  json: JSON
+}
+
+# The output of our \`jsonIdentityMutation\` mutation.
+type JsonIdentityMutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  json: JSON
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+type JwtToken {
+  a: Int
+  b: Int
+  c: Int
+  exp: Int
+  role: String
+}
+
+# All input for the \`mult1\` mutation.
+input Mult1Input {
+  arg0: Int
+  arg1: Int
+
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+}
+
+# The output of our \`mult1\` mutation.
+type Mult1Payload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  integer: Int
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`mult2\` mutation.
+input Mult2Input {
+  arg0: Int
+  arg1: Int
+
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+}
+
+# The output of our \`mult2\` mutation.
+type Mult2Payload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  integer: Int
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`mult3\` mutation.
+input Mult3Input {
+  arg0: Int!
+  arg1: Int!
+
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+}
+
+# The output of our \`mult3\` mutation.
+type Mult3Payload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  integer: Int
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`mult4\` mutation.
+input Mult4Input {
+  arg0: Int!
+  arg1: Int!
+
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+}
+
+# The output of our \`mult4\` mutation.
+type Mult4Payload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  integer: Int
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# The root mutation type which contains root level fields which mutate data.
+type Mutation {
+  # lol, add some stuff 1 mutation
+  add1Mutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: Add1MutationInput!
+  ): Add1MutationPayload!
+
+  # lol, add some stuff 2 mutation
+  add2Mutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: Add2MutationInput!
+  ): Add2MutationPayload!
+
+  # lol, add some stuff 3 mutation
+  add3Mutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: Add3MutationInput!
+  ): Add3MutationPayload!
+
+  # lol, add some stuff 4 mutation
+  add4Mutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: Add4MutationInput!
+  ): Add4MutationPayload!
+
+  # Reads and enables pagination through a set of \`JwtToken\`.
+  authenticate(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: AuthenticateInput!
+  ): AuthenticatePayload!
+
+  # Reads and enables pagination through a set of \`JwtToken\`.
+  authenticateMany(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: AuthenticateManyInput!
+  ): AuthenticateManyPayload!
+
+  # Reads and enables pagination through a set of \`CompoundType\`.
+  compoundTypeMutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CompoundTypeMutationInput!
+  ): CompoundTypeMutationPayload!
+
+  # Creates a single \`CompoundKey\`.
+  createCompoundKey(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CreateCompoundKeyInput!
+  ): CreateCompoundKeyPayload
+
+  # Creates a single \`EdgeCase\`.
+  createEdgeCase(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CreateEdgeCaseInput!
+  ): CreateEdgeCasePayload
+
+  # Creates a single \`ForeignKey\`.
+  createForeignKey(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CreateForeignKeyInput!
+  ): CreateForeignKeyPayload
+
+  # Creates a single \`Person\`.
+  createPerson(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CreatePersonInput!
+  ): CreatePersonPayload
+
+  # Creates a single \`Post\`.
+  createPost(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CreatePostInput!
+  ): CreatePostPayload
+
+  # Creates a single \`SimilarTable1\`.
+  createSimilarTable1(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CreateSimilarTable1Input!
+  ): CreateSimilarTable1Payload
+
+  # Creates a single \`SimilarTable2\`.
+  createSimilarTable2(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CreateSimilarTable2Input!
+  ): CreateSimilarTable2Payload
+
+  # Creates a single \`Type\`.
+  createType(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CreateTypeInput!
+  ): CreateTypePayload
+
+  # Creates a single \`UpdatableView\`.
+  createUpdatableView(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CreateUpdatableViewInput!
+  ): CreateUpdatableViewPayload
+
+  # Deletes a single \`CompoundKey\` using its globally unique id.
+  deleteCompoundKey(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeleteCompoundKeyInput!
+  ): DeleteCompoundKeyPayload
+
+  # Deletes a single \`CompoundKey\` using a unique key.
+  deleteCompoundKeyByPersonId1AndPersonId2(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeleteCompoundKeyByPersonId1AndPersonId2Input!
+  ): DeleteCompoundKeyPayload
+
+  # Deletes a single \`Person\` using its globally unique id.
+  deletePerson(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeletePersonInput!
+  ): DeletePersonPayload
+
+  # Deletes a single \`Person\` using a unique key.
+  deletePersonByEmail(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeletePersonByEmailInput!
+  ): DeletePersonPayload
+
+  # Deletes a single \`Person\` using a unique key.
+  deletePersonById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeletePersonByIdInput!
+  ): DeletePersonPayload
+
+  # Deletes a single \`Post\` using its globally unique id.
+  deletePost(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeletePostInput!
+  ): DeletePostPayload
+
+  # Deletes a single \`Post\` using a unique key.
+  deletePostById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeletePostByIdInput!
+  ): DeletePostPayload
+
+  # Deletes a single \`SimilarTable1\` using its globally unique id.
+  deleteSimilarTable1(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeleteSimilarTable1Input!
+  ): DeleteSimilarTable1Payload
+
+  # Deletes a single \`SimilarTable1\` using a unique key.
+  deleteSimilarTable1ById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeleteSimilarTable1ByIdInput!
+  ): DeleteSimilarTable1Payload
+
+  # Deletes a single \`SimilarTable2\` using its globally unique id.
+  deleteSimilarTable2(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeleteSimilarTable2Input!
+  ): DeleteSimilarTable2Payload
+
+  # Deletes a single \`SimilarTable2\` using a unique key.
+  deleteSimilarTable2ById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeleteSimilarTable2ByIdInput!
+  ): DeleteSimilarTable2Payload
+
+  # Deletes a single \`Type\` using its globally unique id.
+  deleteType(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeleteTypeInput!
+  ): DeleteTypePayload
+
+  # Deletes a single \`Type\` using a unique key.
+  deleteTypeById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeleteTypeByIdInput!
+  ): DeleteTypePayload
+  intSetMutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: IntSetMutationInput!
+  ): IntSetMutationPayload!
+  jsonIdentityMutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: JsonIdentityMutationInput!
+  ): JsonIdentityMutationPayload!
+  mult1(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: Mult1Input!
+  ): Mult1Payload!
+  mult2(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: Mult2Input!
+  ): Mult2Payload!
+  mult3(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: Mult3Input!
+  ): Mult3Payload!
+  mult4(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: Mult4Input!
+  ): Mult4Payload!
+  noArgsMutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: NoArgsMutationInput!
+  ): NoArgsMutationPayload!
+  returnVoidMutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: ReturnVoidMutationInput!
+  ): ReturnVoidMutationPayload!
+
+  # Reads and enables pagination through a set of \`Post\`.
+  tableMutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: TableMutationInput!
+  ): TableMutationPayload!
+
+  # Reads and enables pagination through a set of \`Person\`.
+  tableSetMutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: TableSetMutationInput!
+  ): TableSetMutationPayload!
+  typesMutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: TypesMutationInput!
+  ): TypesMutationPayload!
+
+  # Updates a single \`CompoundKey\` using its globally unique id and a patch.
+  updateCompoundKey(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdateCompoundKeyInput!
+  ): UpdateCompoundKeyPayload
+
+  # Updates a single \`CompoundKey\` using a unique key and a patch.
+  updateCompoundKeyByPersonId1AndPersonId2(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdateCompoundKeyByPersonId1AndPersonId2Input!
+  ): UpdateCompoundKeyPayload
+
+  # Updates a single \`Person\` using its globally unique id and a patch.
+  updatePerson(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdatePersonInput!
+  ): UpdatePersonPayload
+
+  # Updates a single \`Person\` using a unique key and a patch.
+  updatePersonByEmail(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdatePersonByEmailInput!
+  ): UpdatePersonPayload
+
+  # Updates a single \`Person\` using a unique key and a patch.
+  updatePersonById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdatePersonByIdInput!
+  ): UpdatePersonPayload
+
+  # Updates a single \`Post\` using its globally unique id and a patch.
+  updatePost(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdatePostInput!
+  ): UpdatePostPayload
+
+  # Updates a single \`Post\` using a unique key and a patch.
+  updatePostById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdatePostByIdInput!
+  ): UpdatePostPayload
+
+  # Updates a single \`SimilarTable1\` using its globally unique id and a patch.
+  updateSimilarTable1(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdateSimilarTable1Input!
+  ): UpdateSimilarTable1Payload
+
+  # Updates a single \`SimilarTable1\` using a unique key and a patch.
+  updateSimilarTable1ById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdateSimilarTable1ByIdInput!
+  ): UpdateSimilarTable1Payload
+
+  # Updates a single \`SimilarTable2\` using its globally unique id and a patch.
+  updateSimilarTable2(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdateSimilarTable2Input!
+  ): UpdateSimilarTable2Payload
+
+  # Updates a single \`SimilarTable2\` using a unique key and a patch.
+  updateSimilarTable2ById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdateSimilarTable2ByIdInput!
+  ): UpdateSimilarTable2Payload
+
+  # Updates a single \`Type\` using its globally unique id and a patch.
+  updateType(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdateTypeInput!
+  ): UpdateTypePayload
+
+  # Updates a single \`Type\` using a unique key and a patch.
+  updateTypeById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdateTypeByIdInput!
+  ): UpdateTypePayload
+}
+
+type NestedCompoundType {
+  a: CompoundType
+  b: CompoundType
+  bazBuz: Int
+}
+
+# An input for mutations affecting \`NestedCompoundType\`
+input NestedCompoundTypeInput {
+  a: CompoundTypeInput
+  b: CompoundTypeInput
+  bazBuz: Int
+}
+
+# All input for the \`noArgsMutation\` mutation.
+input NoArgsMutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+}
+
+# The output of our \`noArgsMutation\` mutation.
+type NoArgsMutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  integer: Int
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# An object with a globally unique \`ID\`.
+interface Node {
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  nodeId: ID!
+}
+
+type NonUpdatableView implements Node {
+  column: Int
+
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  nodeId: ID!
+}
+
+# A condition to be used against \`NonUpdatableView\` object types. All fields are
+# tested for equality and combined with a logical ‘and.’
+input NonUpdatableViewCondition {
+  # Checks for equality with the object’s \`column\` field.
+  column: Int
+}
+
+# A connection to a list of \`NonUpdatableView\` values.
+type NonUpdatableViewsConnection {
+  # A list of edges which contains the \`NonUpdatableView\` and cursor to aid in pagination.
+  edges: [NonUpdatableViewsEdge!]!
+
+  # A list of \`NonUpdatableView\` objects.
+  nodes: [NonUpdatableView]!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`NonUpdatableView\` you could get from the connection.
+  totalCount: Int
+}
+
+# A \`NonUpdatableView\` edge in the connection.
+type NonUpdatableViewsEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`NonUpdatableView\` at the end of the edge.
+  node: NonUpdatableView!
+}
+
+# Methods to use when ordering \`NonUpdatableView\`.
+enum NonUpdatableViewsOrderBy {
+  COLUMN_ASC
+  COLUMN_DESC
+  NATURAL
+}
+
+# Information about pagination in a connection.
+type PageInfo {
+  # When paginating forwards, the cursor to continue.
+  endCursor: Cursor
+
+  # When paginating forwards, are there more items?
+  hasNextPage: Boolean!
+
+  # When paginating backwards, are there more items?
+  hasPreviousPage: Boolean!
+
+  # When paginating backwards, the cursor to continue.
+  startCursor: Cursor
+}
+
+# A connection to a list of \`Person\` values.
+type PeopleConnection {
+  # A list of edges which contains the \`Person\` and cursor to aid in pagination.
+  edges: [PeopleEdge!]!
+
+  # A list of \`Person\` objects.
+  nodes: [Person]!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`Person\` you could get from the connection.
+  totalCount: Int
+}
+
+# A \`Person\` edge in the connection.
+type PeopleEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`Person\` at the end of the edge.
+  node: Person!
+}
+
+# Methods to use when ordering \`Person\`.
+enum PeopleOrderBy {
+  ABOUT_ASC
+  ABOUT_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  EMAIL_ASC
+  EMAIL_DESC
+  ID_ASC
+  ID_DESC
+  NAME_ASC
+  NAME_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+# Person test comment
+type Person implements Node {
+  about: String
+
+  # Reads and enables pagination through a set of \`CompoundKey\`.
+  compoundKeysByPersonId1(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: CompoundKeyCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`CompoundKey\`.
+    orderBy: CompoundKeysOrderBy = PRIMARY_KEY_ASC
+  ): CompoundKeysConnection!
+
+  # Reads and enables pagination through a set of \`CompoundKey\`.
+  compoundKeysByPersonId2(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: CompoundKeyCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`CompoundKey\`.
+    orderBy: CompoundKeysOrderBy = PRIMARY_KEY_ASC
+  ): CompoundKeysConnection!
+  createdAt: Datetime
+  email: Email!
+  firstName: String
+
+  # Reads and enables pagination through a set of \`Post\`.
+  firstPost: Post
+
+  # Reads and enables pagination through a set of \`ForeignKey\`.
+  foreignKeysByPersonId(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: ForeignKeyCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`ForeignKey\`.
+    orderBy: ForeignKeysOrderBy = NATURAL
+  ): ForeignKeysConnection!
+
+  # Reads and enables pagination through a set of \`Person\`.
+  friends(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+  ): PeopleConnection!
+  id: Int!
+
+  # The person’s name
+  name: String!
+
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  nodeId: ID!
+
+  # Reads and enables pagination through a set of \`Post\`.
+  postsByAuthorId(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: PostCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`Post\`.
+    orderBy: PostsOrderBy = PRIMARY_KEY_ASC
+  ): PostsConnection!
+}
+
+# A condition to be used against \`Person\` object types. All fields are tested for equality and combined with a logical ‘and.’
+input PersonCondition {
+  # Checks for equality with the object’s \`about\` field.
+  about: String
+
+  # Checks for equality with the object’s \`createdAt\` field.
+  createdAt: Datetime
+
+  # Checks for equality with the object’s \`email\` field.
+  email: Email
+
+  # Checks for equality with the object’s \`id\` field.
+  id: Int
+
+  # Checks for equality with the object’s \`name\` field.
+  name: String
+}
+
+# An input for mutations affecting \`Person\`
+input PersonInput {
+  about: String
+  createdAt: Datetime
+  email: Email!
+  id: Int
+
+  # The person’s name
+  name: String!
+}
+
+# Represents an update to a \`Person\`. Fields that are set will be updated.
+input PersonPatch {
+  about: String
+  createdAt: Datetime
+  email: Email
+  id: Int
+
+  # The person’s name
+  name: String
+}
+
+type Post implements Node {
+  authorId: Int
+  body: String
+  headline: String!
+  headlineTrimmed(length: Int, omission: String): String
+  id: Int!
+
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  nodeId: ID!
+
+  # Reads a single \`Person\` that is related to this \`Post\`.
+  personByAuthorId: Person
+}
+
+# A condition to be used against \`Post\` object types. All fields are tested for equality and combined with a logical ‘and.’
+input PostCondition {
+  # Checks for equality with the object’s \`authorId\` field.
+  authorId: Int
+
+  # Checks for equality with the object’s \`body\` field.
+  body: String
+
+  # Checks for equality with the object’s \`headline\` field.
+  headline: String
+
+  # Checks for equality with the object’s \`id\` field.
+  id: Int
+}
+
+# An input for mutations affecting \`Post\`
+input PostInput {
+  authorId: Int
+  body: String
+  headline: String!
+  id: Int
+}
+
+# Represents an update to a \`Post\`. Fields that are set will be updated.
+input PostPatch {
+  authorId: Int
+  body: String
+  headline: String
+  id: Int
+}
+
+# A connection to a list of \`Post\` values.
+type PostsConnection {
+  # A list of edges which contains the \`Post\` and cursor to aid in pagination.
+  edges: [PostsEdge!]!
+
+  # A list of \`Post\` objects.
+  nodes: [Post]!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`Post\` you could get from the connection.
+  totalCount: Int
+}
+
+# A \`Post\` edge in the connection.
+type PostsEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`Post\` at the end of the edge.
+  node: Post!
+}
+
+# Methods to use when ordering \`Post\`.
+enum PostsOrderBy {
+  AUTHOR_ID_ASC
+  AUTHOR_ID_DESC
+  BODY_ASC
+  BODY_DESC
+  HEADLINE_ASC
+  HEADLINE_DESC
+  ID_ASC
+  ID_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+# The root query type which gives access points into the data universe.
+type Query implements Node {
+  # lol, add some stuff 1 query
+  add1Query(arg0: Int!, arg1: Int!): Int
+
+  # lol, add some stuff 2 query
+  add2Query(a: Int!, b: Int!): Int
+
+  # lol, add some stuff 3 query
+  add3Query(a: Int, arg1: Int): Int
+
+  # lol, add some stuff 4 query
+  add4Query(arg0: Int, b: Int): Int
+
+  # Reads and enables pagination through a set of \`CompoundKey\`.
+  allCompoundKeys(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: CompoundKeyCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`CompoundKey\`.
+    orderBy: CompoundKeysOrderBy = PRIMARY_KEY_ASC
+  ): CompoundKeysConnection
+
+  # Reads and enables pagination through a set of \`EdgeCase\`.
+  allEdgeCases(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: EdgeCaseCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`EdgeCase\`.
+    orderBy: EdgeCasesOrderBy = NATURAL
+  ): EdgeCasesConnection
+
+  # Reads and enables pagination through a set of \`ForeignKey\`.
+  allForeignKeys(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: ForeignKeyCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`ForeignKey\`.
+    orderBy: ForeignKeysOrderBy = NATURAL
+  ): ForeignKeysConnection
+
+  # Reads and enables pagination through a set of \`NonUpdatableView\`.
+  allNonUpdatableViews(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: NonUpdatableViewCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`NonUpdatableView\`.
+    orderBy: NonUpdatableViewsOrderBy = NATURAL
+  ): NonUpdatableViewsConnection
+
+  # Reads and enables pagination through a set of \`Person\`.
+  allPeople(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: PersonCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`Person\`.
+    orderBy: PeopleOrderBy = PRIMARY_KEY_ASC
+  ): PeopleConnection
+
+  # Reads and enables pagination through a set of \`Post\`.
+  allPosts(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: PostCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`Post\`.
+    orderBy: PostsOrderBy = PRIMARY_KEY_ASC
+  ): PostsConnection
+
+  # Reads and enables pagination through a set of \`SimilarTable1\`.
+  allSimilarTable1S(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: SimilarTable1Condition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`SimilarTable1\`.
+    orderBy: SimilarTable1SOrderBy = PRIMARY_KEY_ASC
+  ): SimilarTable1SConnection
+
+  # Reads and enables pagination through a set of \`SimilarTable2\`.
+  allSimilarTable2S(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: SimilarTable2Condition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`SimilarTable2\`.
+    orderBy: SimilarTable2SOrderBy = PRIMARY_KEY_ASC
+  ): SimilarTable2SConnection
+
+  # Reads and enables pagination through a set of \`Type\`.
+  allTypes(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: TypeCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`Type\`.
+    orderBy: TypesOrderBy = PRIMARY_KEY_ASC
+  ): TypesConnection
+
+  # Reads and enables pagination through a set of \`UpdatableView\`.
+  allUpdatableViews(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: UpdatableViewCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`UpdatableView\`.
+    orderBy: UpdatableViewsOrderBy = NATURAL
+  ): UpdatableViewsConnection
+
+  # Reads a single \`CompoundKey\` using its globally unique \`ID\`.
+  compoundKey(
+    # The globally unique \`ID\` to be used in selecting a single \`CompoundKey\`.
+    nodeId: ID!
+  ): CompoundKey
+  compoundKeyByPersonId1AndPersonId2(personId1: Int!, personId2: Int!): CompoundKey
+
+  # Reads and enables pagination through a set of \`CompoundType\`.
+  compoundTypeQuery(object: CompoundTypeInput): CompoundType
+  intSetQuery(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+    x: Int
+    y: Int
+    z: Int
+  ): IntSetQueryConnection!
+  jsonIdentity(json: JSON): JSON
+  noArgsQuery: Int
+
+  # Fetches an object given its globally unique \`ID\`.
+  node(
+    # The globally unique \`ID\`.
+    nodeId: ID!
+  ): Node
+
+  # The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
+  nodeId: ID!
+
+  # Reads a single \`Person\` using its globally unique \`ID\`.
+  person(
+    # The globally unique \`ID\` to be used in selecting a single \`Person\`.
+    nodeId: ID!
+  ): Person
+  personByEmail(email: Email!): Person
+  personById(id: Int!): Person
+
+  # Reads a single \`Post\` using its globally unique \`ID\`.
+  post(
+    # The globally unique \`ID\` to be used in selecting a single \`Post\`.
+    nodeId: ID!
+  ): Post
+  postById(id: Int!): Post
+
+  # Exposes the root query type nested one level down. This is helpful for Relay 1
+  # which can only query top level fields if they are in a particular form.
+  query: Query!
+
+  # Reads a single \`SimilarTable1\` using its globally unique \`ID\`.
+  similarTable1(
+    # The globally unique \`ID\` to be used in selecting a single \`SimilarTable1\`.
+    nodeId: ID!
+  ): SimilarTable1
+  similarTable1ById(id: Int!): SimilarTable1
+
+  # Reads a single \`SimilarTable2\` using its globally unique \`ID\`.
+  similarTable2(
+    # The globally unique \`ID\` to be used in selecting a single \`SimilarTable2\`.
+    nodeId: ID!
+  ): SimilarTable2
+  similarTable2ById(id: Int!): SimilarTable2
+
+  # Reads and enables pagination through a set of \`Post\`.
+  tableQuery(id: Int): Post
+
+  # Reads and enables pagination through a set of \`Person\`.
+  tableSetQuery(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+  ): PeopleConnection!
+
+  # Reads a single \`Type\` using its globally unique \`ID\`.
+  type(
+    # The globally unique \`ID\` to be used in selecting a single \`Type\`.
+    nodeId: ID!
+  ): Type
+  typeById(id: Int!): Type
+  typesQuery(a: BigInt!, b: Boolean!, c: String!, d: [Int]!, e: JSON!, f: FloatRangeInput!): Boolean
+}
+
+# All input for the \`returnVoidMutation\` mutation.
+input ReturnVoidMutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+}
+
+# The output of our \`returnVoidMutation\` mutation.
+type ReturnVoidMutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+type SimilarTable1 implements Node {
+  col1: Int
+  col2: Int
+  col3: Int!
+  id: Int!
+
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  nodeId: ID!
+}
+
+# A condition to be used against \`SimilarTable1\` object types. All fields are
+# tested for equality and combined with a logical ‘and.’
+input SimilarTable1Condition {
+  # Checks for equality with the object’s \`col1\` field.
+  col1: Int
+
+  # Checks for equality with the object’s \`col2\` field.
+  col2: Int
+
+  # Checks for equality with the object’s \`col3\` field.
+  col3: Int
+
+  # Checks for equality with the object’s \`id\` field.
+  id: Int
+}
+
+# An input for mutations affecting \`SimilarTable1\`
+input SimilarTable1Input {
+  col1: Int
+  col2: Int
+  col3: Int!
+  id: Int
+}
+
+# Represents an update to a \`SimilarTable1\`. Fields that are set will be updated.
+input SimilarTable1Patch {
+  col1: Int
+  col2: Int
+  col3: Int
+  id: Int
+}
+
+# A connection to a list of \`SimilarTable1\` values.
+type SimilarTable1SConnection {
+  # A list of edges which contains the \`SimilarTable1\` and cursor to aid in pagination.
+  edges: [SimilarTable1SEdge!]!
+
+  # A list of \`SimilarTable1\` objects.
+  nodes: [SimilarTable1]!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`SimilarTable1\` you could get from the connection.
+  totalCount: Int
+}
+
+# A \`SimilarTable1\` edge in the connection.
+type SimilarTable1SEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`SimilarTable1\` at the end of the edge.
+  node: SimilarTable1!
+}
+
+# Methods to use when ordering \`SimilarTable1\`.
+enum SimilarTable1SOrderBy {
+  COL1_ASC
+  COL1_DESC
+  COL2_ASC
+  COL2_DESC
+  COL3_ASC
+  COL3_DESC
+  ID_ASC
+  ID_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+type SimilarTable2 implements Node {
+  col3: Int!
+  col4: Int
+  col5: Int
+  id: Int!
+
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  nodeId: ID!
+}
+
+# A condition to be used against \`SimilarTable2\` object types. All fields are
+# tested for equality and combined with a logical ‘and.’
+input SimilarTable2Condition {
+  # Checks for equality with the object’s \`col3\` field.
+  col3: Int
+
+  # Checks for equality with the object’s \`col4\` field.
+  col4: Int
+
+  # Checks for equality with the object’s \`col5\` field.
+  col5: Int
+
+  # Checks for equality with the object’s \`id\` field.
+  id: Int
+}
+
+# An input for mutations affecting \`SimilarTable2\`
+input SimilarTable2Input {
+  col3: Int!
+  col4: Int
+  col5: Int
+  id: Int
+}
+
+# Represents an update to a \`SimilarTable2\`. Fields that are set will be updated.
+input SimilarTable2Patch {
+  col3: Int
+  col4: Int
+  col5: Int
+  id: Int
+}
+
+# A connection to a list of \`SimilarTable2\` values.
+type SimilarTable2SConnection {
+  # A list of edges which contains the \`SimilarTable2\` and cursor to aid in pagination.
+  edges: [SimilarTable2SEdge!]!
+
+  # A list of \`SimilarTable2\` objects.
+  nodes: [SimilarTable2]!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`SimilarTable2\` you could get from the connection.
+  totalCount: Int
+}
+
+# A \`SimilarTable2\` edge in the connection.
+type SimilarTable2SEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`SimilarTable2\` at the end of the edge.
+  node: SimilarTable2!
+}
+
+# Methods to use when ordering \`SimilarTable2\`.
+enum SimilarTable2SOrderBy {
+  COL3_ASC
+  COL3_DESC
+  COL4_ASC
+  COL4_DESC
+  COL5_ASC
+  COL5_DESC
+  ID_ASC
+  ID_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+# All input for the \`tableMutation\` mutation.
+input TableMutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int
+}
+
+# The output of our \`tableMutation\` mutation.
+type TableMutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # Reads a single \`Person\` that is related to this \`Post\`.
+  personByAuthorId: Person
+  post: Post
+
+  # An edge for the type. May be used by Relay 1.
+  postEdge(
+    # The method to use when ordering \`Post\`.
+    orderBy: PostsOrderBy = PRIMARY_KEY_ASC
+  ): PostsEdge
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`tableSetMutation\` mutation.
+input TableSetMutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+}
+
+# The output of our \`tableSetMutation\` mutation.
+type TableSetMutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  people: [Person]
+
+  # An edge for the type. May be used by Relay 1.
+  personEdge(
+    # The method to use when ordering \`Person\`.
+    orderBy: PeopleOrderBy = PRIMARY_KEY_ASC
+  ): PeopleEdge
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# The exact time of day, does not include the date. May or may not have a timezone offset.
+scalar Time
+
+type Type implements Node {
+  anIntRange: AnIntRange!
+  bigint: BigInt!
+  boolean: Boolean!
+  compoundType: CompoundType!
+  date: Date!
+  daterange: DateRange!
+  decimal: Float!
+  domain: AnInt!
+  domain2: AnotherInt!
+  enum: Color!
+  enumArray: [Color]!
+  id: Int!
+  interval: Interval!
+  json: JSON!
+  jsonb: JSON!
+  money: Float!
+  nestedCompoundType: NestedCompoundType!
+
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  nodeId: ID!
+  nullableRange: FloatRange
+  numeric: Float!
+  numrange: FloatRange!
+  smallint: Int!
+  textArray: [String]!
+  time: Time!
+  timestamp: Datetime!
+  timestamptz: Datetime!
+  timetz: Time!
+  varchar: String!
+}
+
+# A condition to be used against \`Type\` object types. All fields are tested for equality and combined with a logical ‘and.’
+input TypeCondition {
+  # Checks for equality with the object’s \`anIntRange\` field.
+  anIntRange: AnIntRangeInput
+
+  # Checks for equality with the object’s \`bigint\` field.
+  bigint: BigInt
+
+  # Checks for equality with the object’s \`boolean\` field.
+  boolean: Boolean
+
+  # Checks for equality with the object’s \`compoundType\` field.
+  compoundType: CompoundTypeInput
+
+  # Checks for equality with the object’s \`date\` field.
+  date: Date
+
+  # Checks for equality with the object’s \`daterange\` field.
+  daterange: DateRangeInput
+
+  # Checks for equality with the object’s \`decimal\` field.
+  decimal: Float
+
+  # Checks for equality with the object’s \`domain\` field.
+  domain: AnInt
+
+  # Checks for equality with the object’s \`domain2\` field.
+  domain2: AnotherInt
+
+  # Checks for equality with the object’s \`enum\` field.
+  enum: Color
+
+  # Checks for equality with the object’s \`enumArray\` field.
+  enumArray: [Color]
+
+  # Checks for equality with the object’s \`id\` field.
+  id: Int
+
+  # Checks for equality with the object’s \`interval\` field.
+  interval: IntervalInput
+
+  # Checks for equality with the object’s \`json\` field.
+  json: JSON
+
+  # Checks for equality with the object’s \`jsonb\` field.
+  jsonb: JSON
+
+  # Checks for equality with the object’s \`money\` field.
+  money: Float
+
+  # Checks for equality with the object’s \`nestedCompoundType\` field.
+  nestedCompoundType: NestedCompoundTypeInput
+
+  # Checks for equality with the object’s \`nullableRange\` field.
+  nullableRange: FloatRangeInput
+
+  # Checks for equality with the object’s \`numeric\` field.
+  numeric: Float
+
+  # Checks for equality with the object’s \`numrange\` field.
+  numrange: FloatRangeInput
+
+  # Checks for equality with the object’s \`smallint\` field.
+  smallint: Int
+
+  # Checks for equality with the object’s \`textArray\` field.
+  textArray: [String]
+
+  # Checks for equality with the object’s \`time\` field.
+  time: Time
+
+  # Checks for equality with the object’s \`timestamp\` field.
+  timestamp: Datetime
+
+  # Checks for equality with the object’s \`timestamptz\` field.
+  timestamptz: Datetime
+
+  # Checks for equality with the object’s \`timetz\` field.
+  timetz: Time
+
+  # Checks for equality with the object’s \`varchar\` field.
+  varchar: String
+}
+
+# An input for mutations affecting \`Type\`
+input TypeInput {
+  anIntRange: AnIntRangeInput!
+  bigint: BigInt!
+  boolean: Boolean!
+  compoundType: CompoundTypeInput!
+  date: Date!
+  daterange: DateRangeInput!
+  decimal: Float!
+  domain: AnInt!
+  domain2: AnotherInt!
+  enum: Color!
+  enumArray: [Color]!
+  id: Int
+  interval: IntervalInput!
+  json: JSON!
+  jsonb: JSON!
+  money: Float!
+  nestedCompoundType: NestedCompoundTypeInput!
+  nullableRange: FloatRangeInput
+  numeric: Float!
+  numrange: FloatRangeInput!
+  smallint: Int!
+  textArray: [String]!
+  time: Time!
+  timestamp: Datetime!
+  timestamptz: Datetime!
+  timetz: Time!
+  varchar: String!
+}
+
+# Represents an update to a \`Type\`. Fields that are set will be updated.
+input TypePatch {
+  anIntRange: AnIntRangeInput
+  bigint: BigInt
+  boolean: Boolean
+  compoundType: CompoundTypeInput
+  date: Date
+  daterange: DateRangeInput
+  decimal: Float
+  domain: AnInt
+  domain2: AnotherInt
+  enum: Color
+  enumArray: [Color]
+  id: Int
+  interval: IntervalInput
+  json: JSON
+  jsonb: JSON
+  money: Float
+  nestedCompoundType: NestedCompoundTypeInput
+  nullableRange: FloatRangeInput
+  numeric: Float
+  numrange: FloatRangeInput
+  smallint: Int
+  textArray: [String]
+  time: Time
+  timestamp: Datetime
+  timestamptz: Datetime
+  timetz: Time
+  varchar: String
+}
+
+# A connection to a list of \`Type\` values.
+type TypesConnection {
+  # A list of edges which contains the \`Type\` and cursor to aid in pagination.
+  edges: [TypesEdge!]!
+
+  # A list of \`Type\` objects.
+  nodes: [Type]!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`Type\` you could get from the connection.
+  totalCount: Int
+}
+
+# A \`Type\` edge in the connection.
+type TypesEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`Type\` at the end of the edge.
+  node: Type!
+}
+
+# All input for the \`typesMutation\` mutation.
+input TypesMutationInput {
+  a: BigInt!
+  b: Boolean!
+  c: String!
+
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  d: [Int]!
+  e: JSON!
+  f: FloatRangeInput!
+}
+
+# The output of our \`typesMutation\` mutation.
+type TypesMutationPayload {
+  boolean: Boolean
+
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# Methods to use when ordering \`Type\`.
+enum TypesOrderBy {
+  AN_INT_RANGE_ASC
+  AN_INT_RANGE_DESC
+  BIGINT_ASC
+  BIGINT_DESC
+  BOOLEAN_ASC
+  BOOLEAN_DESC
+  COMPOUND_TYPE_ASC
+  COMPOUND_TYPE_DESC
+  DATE_ASC
+  DATE_DESC
+  DATERANGE_ASC
+  DATERANGE_DESC
+  DECIMAL_ASC
+  DECIMAL_DESC
+  DOMAIN_ASC
+  DOMAIN_DESC
+  DOMAIN2_ASC
+  DOMAIN2_DESC
+  ENUM_ARRAY_ASC
+  ENUM_ARRAY_DESC
+  ENUM_ASC
+  ENUM_DESC
+  ID_ASC
+  ID_DESC
+  INTERVAL_ASC
+  INTERVAL_DESC
+  JSON_ASC
+  JSON_DESC
+  JSONB_ASC
+  JSONB_DESC
+  MONEY_ASC
+  MONEY_DESC
+  NATURAL
+  NESTED_COMPOUND_TYPE_ASC
+  NESTED_COMPOUND_TYPE_DESC
+  NULLABLE_RANGE_ASC
+  NULLABLE_RANGE_DESC
+  NUMERIC_ASC
+  NUMERIC_DESC
+  NUMRANGE_ASC
+  NUMRANGE_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  SMALLINT_ASC
+  SMALLINT_DESC
+  TEXT_ARRAY_ASC
+  TEXT_ARRAY_DESC
+  TIME_ASC
+  TIME_DESC
+  TIMESTAMP_ASC
+  TIMESTAMP_DESC
+  TIMESTAMPTZ_ASC
+  TIMESTAMPTZ_DESC
+  TIMETZ_ASC
+  TIMETZ_DESC
+  VARCHAR_ASC
+  VARCHAR_DESC
+}
+
+# YOYOYO!!
+type UpdatableView implements Node {
+  # This is constantly 2
+  constant: Int
+  description: String
+  name: String
+
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  nodeId: ID!
+  x: Int
+}
+
+# A condition to be used against \`UpdatableView\` object types. All fields are
+# tested for equality and combined with a logical ‘and.’
+input UpdatableViewCondition {
+  # Checks for equality with the object’s \`constant\` field.
+  constant: Int
+
+  # Checks for equality with the object’s \`description\` field.
+  description: String
+
+  # Checks for equality with the object’s \`name\` field.
+  name: String
+
+  # Checks for equality with the object’s \`x\` field.
+  x: Int
+}
+
+# An input for mutations affecting \`UpdatableView\`
+input UpdatableViewInput {
+  # This is constantly 2
+  constant: Int
+  description: String
+  name: String
+  x: Int
+}
+
+# A connection to a list of \`UpdatableView\` values.
+type UpdatableViewsConnection {
+  # A list of edges which contains the \`UpdatableView\` and cursor to aid in pagination.
+  edges: [UpdatableViewsEdge!]!
+
+  # A list of \`UpdatableView\` objects.
+  nodes: [UpdatableView]!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`UpdatableView\` you could get from the connection.
+  totalCount: Int
+}
+
+# A \`UpdatableView\` edge in the connection.
+type UpdatableViewsEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`UpdatableView\` at the end of the edge.
+  node: UpdatableView!
+}
+
+# Methods to use when ordering \`UpdatableView\`.
+enum UpdatableViewsOrderBy {
+  CONSTANT_ASC
+  CONSTANT_DESC
+  DESCRIPTION_ASC
+  DESCRIPTION_DESC
+  NAME_ASC
+  NAME_DESC
+  NATURAL
+  X_ASC
+  X_DESC
+}
+
+# All input for the \`updateCompoundKeyByPersonId1AndPersonId2\` mutation.
+input UpdateCompoundKeyByPersonId1AndPersonId2Input {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # An object where the defined keys will be set on the \`CompoundKey\` being updated.
+  compoundKeyPatch: CompoundKeyPatch!
+  personId1: Int!
+  personId2: Int!
+}
+
+# All input for the \`updateCompoundKey\` mutation.
+input UpdateCompoundKeyInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # An object where the defined keys will be set on the \`CompoundKey\` being updated.
+  compoundKeyPatch: CompoundKeyPatch!
+
+  # The globally unique \`ID\` which will identify a single \`CompoundKey\` to be updated.
+  nodeId: ID!
+}
+
+# The output of our update \`CompoundKey\` mutation.
+type UpdateCompoundKeyPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # The \`CompoundKey\` that was updated by this mutation.
+  compoundKey: CompoundKey
+
+  # An edge for the type. May be used by Relay 1.
+  compoundKeyEdge(
+    # The method to use when ordering \`CompoundKey\`.
+    orderBy: CompoundKeysOrderBy = PRIMARY_KEY_ASC
+  ): CompoundKeysEdge
+
+  # Reads a single \`Person\` that is related to this \`CompoundKey\`.
+  personByPersonId1: Person
+
+  # Reads a single \`Person\` that is related to this \`CompoundKey\`.
+  personByPersonId2: Person
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`updatePersonByEmail\` mutation.
+input UpdatePersonByEmailInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  email: Email!
+
+  # An object where the defined keys will be set on the \`Person\` being updated.
+  personPatch: PersonPatch!
+}
+
+# All input for the \`updatePersonById\` mutation.
+input UpdatePersonByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+
+  # An object where the defined keys will be set on the \`Person\` being updated.
+  personPatch: PersonPatch!
+}
+
+# All input for the \`updatePerson\` mutation.
+input UpdatePersonInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`Person\` to be updated.
+  nodeId: ID!
+
+  # An object where the defined keys will be set on the \`Person\` being updated.
+  personPatch: PersonPatch!
+}
+
+# The output of our update \`Person\` mutation.
+type UpdatePersonPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # The \`Person\` that was updated by this mutation.
+  person: Person
+
+  # An edge for the type. May be used by Relay 1.
+  personEdge(
+    # The method to use when ordering \`Person\`.
+    orderBy: PeopleOrderBy = PRIMARY_KEY_ASC
+  ): PeopleEdge
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`updatePostById\` mutation.
+input UpdatePostByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+
+  # An object where the defined keys will be set on the \`Post\` being updated.
+  postPatch: PostPatch!
+}
+
+# All input for the \`updatePost\` mutation.
+input UpdatePostInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`Post\` to be updated.
+  nodeId: ID!
+
+  # An object where the defined keys will be set on the \`Post\` being updated.
+  postPatch: PostPatch!
+}
+
+# The output of our update \`Post\` mutation.
+type UpdatePostPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # Reads a single \`Person\` that is related to this \`Post\`.
+  personByAuthorId: Person
+
+  # The \`Post\` that was updated by this mutation.
+  post: Post
+
+  # An edge for the type. May be used by Relay 1.
+  postEdge(
+    # The method to use when ordering \`Post\`.
+    orderBy: PostsOrderBy = PRIMARY_KEY_ASC
+  ): PostsEdge
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`updateSimilarTable1ById\` mutation.
+input UpdateSimilarTable1ByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+
+  # An object where the defined keys will be set on the \`SimilarTable1\` being updated.
+  similarTable1Patch: SimilarTable1Patch!
+}
+
+# All input for the \`updateSimilarTable1\` mutation.
+input UpdateSimilarTable1Input {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`SimilarTable1\` to be updated.
+  nodeId: ID!
+
+  # An object where the defined keys will be set on the \`SimilarTable1\` being updated.
+  similarTable1Patch: SimilarTable1Patch!
+}
+
+# The output of our update \`SimilarTable1\` mutation.
+type UpdateSimilarTable1Payload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+
+  # The \`SimilarTable1\` that was updated by this mutation.
+  similarTable1: SimilarTable1
+
+  # An edge for the type. May be used by Relay 1.
+  similarTable1Edge(
+    # The method to use when ordering \`SimilarTable1\`.
+    orderBy: SimilarTable1SOrderBy = PRIMARY_KEY_ASC
+  ): SimilarTable1SEdge
+}
+
+# All input for the \`updateSimilarTable2ById\` mutation.
+input UpdateSimilarTable2ByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+
+  # An object where the defined keys will be set on the \`SimilarTable2\` being updated.
+  similarTable2Patch: SimilarTable2Patch!
+}
+
+# All input for the \`updateSimilarTable2\` mutation.
+input UpdateSimilarTable2Input {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`SimilarTable2\` to be updated.
+  nodeId: ID!
+
+  # An object where the defined keys will be set on the \`SimilarTable2\` being updated.
+  similarTable2Patch: SimilarTable2Patch!
+}
+
+# The output of our update \`SimilarTable2\` mutation.
+type UpdateSimilarTable2Payload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+
+  # The \`SimilarTable2\` that was updated by this mutation.
+  similarTable2: SimilarTable2
+
+  # An edge for the type. May be used by Relay 1.
+  similarTable2Edge(
+    # The method to use when ordering \`SimilarTable2\`.
+    orderBy: SimilarTable2SOrderBy = PRIMARY_KEY_ASC
+  ): SimilarTable2SEdge
+}
+
+# All input for the \`updateTypeById\` mutation.
+input UpdateTypeByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+
+  # An object where the defined keys will be set on the \`Type\` being updated.
+  typePatch: TypePatch!
+}
+
+# All input for the \`updateType\` mutation.
+input UpdateTypeInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`Type\` to be updated.
+  nodeId: ID!
+
+  # An object where the defined keys will be set on the \`Type\` being updated.
+  typePatch: TypePatch!
+}
+
+# The output of our update \`Type\` mutation.
+type UpdateTypePayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+
+  # The \`Type\` that was updated by this mutation.
+  type: Type
+
+  # An edge for the type. May be used by Relay 1.
+  typeEdge(
+    # The method to use when ordering \`Type\`.
+    orderBy: TypesOrderBy = PRIMARY_KEY_ASC
+  ): TypesEdge
+}
+
+# A universally unique identifier as defined by [RFC 4122](https://tools.ietf.org/html/rfc4122).
+scalar UUID
+"
+`;
+
+exports[`prints a schema without default mutations 1`] = `
+"# A signed eight-byte integer. The upper big integer values are greater then the
+# max value for a JavaScript number. Therefore all big integers will be output as
+# strings and not numbers.
+scalar BigInt
+
+type CompoundKey implements Node {
+  extra: Boolean
+
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  nodeId: ID!
+
+  # Reads a single \`Person\` that is related to this \`CompoundKey\`.
+  personByPersonId1: Person!
+
+  # Reads a single \`Person\` that is related to this \`CompoundKey\`.
+  personByPersonId2: Person!
+  personId1: Int!
+  personId2: Int!
+}
+
+# A condition to be used against \`CompoundKey\` object types. All fields are tested
+# for equality and combined with a logical ‘and.’
+input CompoundKeyCondition {
+  # Checks for equality with the object’s \`extra\` field.
+  extra: Boolean
+
+  # Checks for equality with the object’s \`personId1\` field.
+  personId1: Int
+
+  # Checks for equality with the object’s \`personId2\` field.
+  personId2: Int
+}
+
+# A connection to a list of \`CompoundKey\` values.
+type CompoundKeysConnection {
+  # A list of edges which contains the \`CompoundKey\` and cursor to aid in pagination.
+  edges: [CompoundKeysEdge!]!
+
+  # A list of \`CompoundKey\` objects.
+  nodes: [CompoundKey]!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`CompoundKey\` you could get from the connection.
+  totalCount: Int
+}
+
+# A \`CompoundKey\` edge in the connection.
+type CompoundKeysEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`CompoundKey\` at the end of the edge.
+  node: CompoundKey!
+}
+
+# Methods to use when ordering \`CompoundKey\`.
+enum CompoundKeysOrderBy {
+  EXTRA_ASC
+  EXTRA_DESC
+  NATURAL
+  PERSON_ID_1_ASC
+  PERSON_ID_1_DESC
+  PERSON_ID_2_ASC
+  PERSON_ID_2_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+# A location in a connection that can be used for resuming pagination.
+scalar Cursor
+
+# A point in time as described by the [ISO
+# 8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
+scalar Datetime
+
+type EdgeCase implements Node {
+  computed: String
+
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  nodeId: ID!
+  notNullHasDefault: Boolean!
+  rowId: Int
+  wontCastEasy: Int
+}
+
+# A condition to be used against \`EdgeCase\` object types. All fields are tested
+# for equality and combined with a logical ‘and.’
+input EdgeCaseCondition {
+  # Checks for equality with the object’s \`notNullHasDefault\` field.
+  notNullHasDefault: Boolean
+
+  # Checks for equality with the object’s \`rowId\` field.
+  rowId: Int
+
+  # Checks for equality with the object’s \`wontCastEasy\` field.
+  wontCastEasy: Int
+}
+
+# A connection to a list of \`EdgeCase\` values.
+type EdgeCasesConnection {
+  # A list of edges which contains the \`EdgeCase\` and cursor to aid in pagination.
+  edges: [EdgeCasesEdge!]!
+
+  # A list of \`EdgeCase\` objects.
+  nodes: [EdgeCase]!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`EdgeCase\` you could get from the connection.
+  totalCount: Int
+}
+
+# A \`EdgeCase\` edge in the connection.
+type EdgeCasesEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`EdgeCase\` at the end of the edge.
+  node: EdgeCase!
+}
+
+# Methods to use when ordering \`EdgeCase\`.
+enum EdgeCasesOrderBy {
+  NATURAL
+  NOT_NULL_HAS_DEFAULT_ASC
+  NOT_NULL_HAS_DEFAULT_DESC
+  ROW_ID_ASC
+  ROW_ID_DESC
+  WONT_CAST_EASY_ASC
+  WONT_CAST_EASY_DESC
+}
+
+scalar Email
+
+# The value at one end of a range. A range can either include this value, or not.
+input FloatRangeBoundInput {
+  # Whether or not the value of this bound is included in the range.
+  inclusive: Boolean!
+
+  # The value at one end of our range.
+  value: Float!
+}
+
+# A range of \`Float\`.
+input FloatRangeInput {
+  # The ending bound of our range.
+  end: FloatRangeBoundInput
+
+  # The starting bound of our range.
+  start: FloatRangeBoundInput
+}
+
+# All input for the \`intSetMutation\` mutation.
+input IntSetMutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  x: Int
+  y: Int
+  z: Int
+}
+
+# The output of our \`intSetMutation\` mutation.
+type IntSetMutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  integers: [Int]
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# A connection to a list of \`Int\` values.
+type IntSetQueryConnection {
+  # A list of edges which contains the \`Int\` and cursor to aid in pagination.
+  edges: [IntSetQueryEdge!]!
+
+  # A list of \`Int\` objects.
+  nodes: [Int]!
+}
+
+# A \`Int\` edge in the connection.
+type IntSetQueryEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`Int\` at the end of the edge.
+  node: Int
+}
+
+# A JavaScript object encoded in the JSON format as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+scalar JSON
+
+# All input for the \`jsonIdentityMutation\` mutation.
+input JsonIdentityMutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  json: JSON
+}
+
+# The output of our \`jsonIdentityMutation\` mutation.
+type JsonIdentityMutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  json: JSON
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# The root mutation type which contains root level fields which mutate data.
+type Mutation {
+  intSetMutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: IntSetMutationInput!
+  ): IntSetMutationPayload!
+  jsonIdentityMutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: JsonIdentityMutationInput!
+  ): JsonIdentityMutationPayload!
+  noArgsMutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: NoArgsMutationInput!
+  ): NoArgsMutationPayload!
+
+  # Reads and enables pagination through a set of \`Post\`.
+  tableMutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: TableMutationInput!
+  ): TableMutationPayload!
+
+  # Reads and enables pagination through a set of \`Person\`.
+  tableSetMutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: TableSetMutationInput!
+  ): TableSetMutationPayload!
+  typesMutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: TypesMutationInput!
+  ): TypesMutationPayload!
+}
+
+# All input for the \`noArgsMutation\` mutation.
+input NoArgsMutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+}
+
+# The output of our \`noArgsMutation\` mutation.
+type NoArgsMutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  integer: Int
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# An object with a globally unique \`ID\`.
+interface Node {
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  nodeId: ID!
+}
+
+# Information about pagination in a connection.
+type PageInfo {
+  # When paginating forwards, the cursor to continue.
+  endCursor: Cursor
+
+  # When paginating forwards, are there more items?
+  hasNextPage: Boolean!
+
+  # When paginating backwards, are there more items?
+  hasPreviousPage: Boolean!
+
+  # When paginating backwards, the cursor to continue.
+  startCursor: Cursor
+}
+
+# A connection to a list of \`Person\` values.
+type PeopleConnection {
+  # A list of edges which contains the \`Person\` and cursor to aid in pagination.
+  edges: [PeopleEdge!]!
+
+  # A list of \`Person\` objects.
+  nodes: [Person]!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`Person\` you could get from the connection.
+  totalCount: Int
+}
+
+# A \`Person\` edge in the connection.
+type PeopleEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`Person\` at the end of the edge.
+  node: Person!
+}
+
+# Methods to use when ordering \`Person\`.
+enum PeopleOrderBy {
+  ABOUT_ASC
+  ABOUT_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  EMAIL_ASC
+  EMAIL_DESC
+  ID_ASC
+  ID_DESC
+  NAME_ASC
+  NAME_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+# Person test comment
+type Person implements Node {
+  about: String
+
+  # Reads and enables pagination through a set of \`CompoundKey\`.
+  compoundKeysByPersonId1(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: CompoundKeyCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`CompoundKey\`.
+    orderBy: CompoundKeysOrderBy = PRIMARY_KEY_ASC
+  ): CompoundKeysConnection!
+
+  # Reads and enables pagination through a set of \`CompoundKey\`.
+  compoundKeysByPersonId2(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: CompoundKeyCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`CompoundKey\`.
+    orderBy: CompoundKeysOrderBy = PRIMARY_KEY_ASC
+  ): CompoundKeysConnection!
+  createdAt: Datetime
+  email: Email!
+  firstName: String
+
+  # Reads and enables pagination through a set of \`Post\`.
+  firstPost: Post
+
+  # Reads and enables pagination through a set of \`Person\`.
+  friends(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+  ): PeopleConnection!
+  id: Int!
+
+  # The person’s name
+  name: String!
+
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  nodeId: ID!
+}
+
+# A condition to be used against \`Person\` object types. All fields are tested for equality and combined with a logical ‘and.’
+input PersonCondition {
+  # Checks for equality with the object’s \`about\` field.
+  about: String
+
+  # Checks for equality with the object’s \`createdAt\` field.
+  createdAt: Datetime
+
+  # Checks for equality with the object’s \`email\` field.
+  email: Email
+
+  # Checks for equality with the object’s \`id\` field.
+  id: Int
+
+  # Checks for equality with the object’s \`name\` field.
+  name: String
+}
+
+type Post implements Node {
+  authorId: Int
+  body: String
+  headline: String!
+  id: Int!
+
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  nodeId: ID!
+}
+
+# The root query type which gives access points into the data universe.
+type Query implements Node {
+  # Reads and enables pagination through a set of \`CompoundKey\`.
+  allCompoundKeys(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: CompoundKeyCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`CompoundKey\`.
+    orderBy: CompoundKeysOrderBy = PRIMARY_KEY_ASC
+  ): CompoundKeysConnection
+
+  # Reads and enables pagination through a set of \`EdgeCase\`.
+  allEdgeCases(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: EdgeCaseCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`EdgeCase\`.
+    orderBy: EdgeCasesOrderBy = NATURAL
+  ): EdgeCasesConnection
+
+  # Reads and enables pagination through a set of \`Person\`.
+  allPeople(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: PersonCondition
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # The method to use when ordering \`Person\`.
+    orderBy: PeopleOrderBy = PRIMARY_KEY_ASC
+  ): PeopleConnection
+
+  # Reads a single \`CompoundKey\` using its globally unique \`ID\`.
+  compoundKey(
+    # The globally unique \`ID\` to be used in selecting a single \`CompoundKey\`.
+    nodeId: ID!
+  ): CompoundKey
+  compoundKeyByPersonId1AndPersonId2(personId1: Int!, personId2: Int!): CompoundKey
+  intSetQuery(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+    x: Int
+    y: Int
+    z: Int
+  ): IntSetQueryConnection!
+  jsonIdentity(json: JSON): JSON
+  noArgsQuery: Int
+
+  # Fetches an object given its globally unique \`ID\`.
+  node(
+    # The globally unique \`ID\`.
+    nodeId: ID!
+  ): Node
+
+  # The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
+  nodeId: ID!
+
+  # Reads a single \`Person\` using its globally unique \`ID\`.
+  person(
+    # The globally unique \`ID\` to be used in selecting a single \`Person\`.
+    nodeId: ID!
+  ): Person
+  personByEmail(email: Email!): Person
+  personById(id: Int!): Person
+
+  # Exposes the root query type nested one level down. This is helpful for Relay 1
+  # which can only query top level fields if they are in a particular form.
+  query: Query!
+
+  # Reads and enables pagination through a set of \`Post\`.
+  tableQuery(id: Int): Post
+
+  # Reads and enables pagination through a set of \`Person\`.
+  tableSetQuery(
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+  ): PeopleConnection!
+  typesQuery(a: BigInt!, b: Boolean!, c: String!, d: [Int]!, e: JSON!, f: FloatRangeInput!): Boolean
+}
+
+# All input for the \`tableMutation\` mutation.
+input TableMutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int
+}
+
+# The output of our \`tableMutation\` mutation.
+type TableMutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  post: Post
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`tableSetMutation\` mutation.
+input TableSetMutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+}
+
+# The output of our \`tableSetMutation\` mutation.
+type TableSetMutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  people: [Person]
+
+  # An edge for the type. May be used by Relay 1.
+  personEdge(
+    # The method to use when ordering \`Person\`.
+    orderBy: PeopleOrderBy = PRIMARY_KEY_ASC
+  ): PeopleEdge
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`typesMutation\` mutation.
+input TypesMutationInput {
+  a: BigInt!
+  b: Boolean!
+  c: String!
+
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  d: [Int]!
+  e: JSON!
+  f: FloatRangeInput!
+}
+
+# The output of our \`typesMutation\` mutation.
+type TypesMutationPayload {
+  boolean: Boolean
+
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+"
+`;

--- a/packages/postgraphql-build/__tests__/integration/schema.test.js
+++ b/packages/postgraphql-build/__tests__/integration/schema.test.js
@@ -1,0 +1,50 @@
+// TODO: There may be some excessive waste, if we could somehow filter what
+// these guys see, that would be great 👍
+
+const printSchemaOrdered = require("../printSchemaOrdered");
+const { withPgClient } = require("../helpers");
+const { createPostGraphQLSchema } = require("../..");
+
+// This test suite can be flaky. Increase it’s timeout.
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 20;
+
+let testResults;
+
+const testFixtures = [
+  {
+    name: "prints a schema with the default options",
+    createSchema: client => createPostGraphQLSchema(client, ["a", "b", "c"]),
+  },
+  {
+    name: "prints a schema with Relay 1 style ids",
+    createSchema: client =>
+      createPostGraphQLSchema(client, "c", { classicIds: true }),
+  },
+  {
+    name: "prints a schema with a JWT generating mutation",
+    createSchema: client =>
+      createPostGraphQLSchema(client, "b", {
+        jwtSecret: "secret",
+        jwtPgTypeIdentifier: "b.jwt_token",
+      }),
+  },
+  {
+    name: "prints a schema without default mutations",
+    createSchema: client =>
+      createPostGraphQLSchema(client, "c", { disableDefaultMutations: true }),
+  },
+];
+
+beforeAll(() => {
+  testResults = testFixtures.map(testFixture =>
+    withPgClient(async client => {
+      return await testFixture.createSchema(client);
+    })
+  );
+});
+
+for (let i = 0; i < testFixtures.length; i++) {
+  test(testFixtures[i].name, async () => {
+    expect(printSchemaOrdered(await testResults[i])).toMatchSnapshot();
+  });
+}

--- a/packages/postgraphql-build/__tests__/printSchemaOrdered.js
+++ b/packages/postgraphql-build/__tests__/printSchemaOrdered.js
@@ -1,0 +1,37 @@
+const { parse, buildASTSchema } = require("graphql");
+const { printSchema } = require("graphql/utilities");
+
+module.exports = function printSchemaOrdered(originalSchema) {
+  // Clone schema so we don't damage anything
+  const schema = buildASTSchema(parse(printSchema(originalSchema)));
+
+  const typeMap = schema.getTypeMap();
+  Object.keys(typeMap).forEach(name => {
+    const gqlType = typeMap[name];
+
+    // Object?
+    if (gqlType.getFields) {
+      const fields = gqlType.getFields();
+      const keys = Object.keys(fields).sort();
+      keys.forEach(key => {
+        const value = fields[key];
+
+        // Move the key to the end of the object
+        delete fields[key];
+        fields[key] = value;
+
+        // Sort args
+        if (value.args) {
+          value.args.sort((a, b) => a.name.localeCompare(b.name));
+        }
+      });
+    }
+
+    // Enum?
+    if (gqlType.getValues) {
+      gqlType.getValues().sort((a, b) => a.name.localeCompare(b.name));
+    }
+  });
+
+  return printSchema(schema);
+};


### PR DESCRIPTION
So we can validate fields that have been added/removed when reviewing Pull Requests. Uses alphabetical schema ordering so that diffs are easier to read.